### PR TITLE
feat: add initial Folia compatibility

### DIFF
--- a/BetterHorses/build.gradle
+++ b/BetterHorses/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'io.papermc.paper:paper-api:1.20.6-R0.1-SNAPSHOT'
+    compileOnly 'dev.folia:folia-api:1.20.6-R0.1-SNAPSHOT'
     compileOnly 'com.comphenix.protocol:ProtocolLib:5.3.0'
 }
 

--- a/BetterHorses/src/main/java/me/luisgamedev/BetterHorses.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/BetterHorses.java
@@ -8,11 +8,11 @@ import me.luisgamedev.commands.CustomHorseCommand;
 import me.luisgamedev.commands.HorseCommand;
 import me.luisgamedev.commands.HorseCommandCompleter;
 import me.luisgamedev.commands.HorseCreateTabCompleter;
-import me.luisgamedev.growing.HorseGrowthManager;
 import me.luisgamedev.listeners.*;
 import me.luisgamedev.tasks.TraitParticleTask;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 
 public class BetterHorses extends JavaPlugin {
 
@@ -53,11 +53,11 @@ public class BetterHorses extends JavaPlugin {
 
         new HorseGrowthManager(this).start();
 
-        Bukkit.getScheduler().runTaskTimer(
+        Bukkit.getGlobalRegionScheduler().runAtFixedRate(
                 this,
-                new TraitParticleTask(),
-                20L, // delay 1s
-                20L  // repeat every 1s
+                (ScheduledTask task) -> new TraitParticleTask().run(),
+                20L,
+                20L
         );
     }
 

--- a/BetterHorses/src/main/java/me/luisgamedev/listeners/HorseJumpListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/listeners/HorseJumpListener.java
@@ -14,7 +14,7 @@ import org.bukkit.event.entity.HorseJumpEvent;
 import org.bukkit.event.vehicle.VehicleExitEvent;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.persistence.PersistentDataType;
-import org.bukkit.scheduler.BukkitRunnable;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -35,38 +35,31 @@ public class HorseJumpListener implements Listener {
         horse.setMetadata("SkyburstCandidate", new FixedMetadataValue(BetterHorses.getInstance(), true));
         airborneHorses.add(horse);
 
-        new BukkitRunnable() {
-            @Override
-            public void run() {
+        horse.getScheduler().runDelayed(BetterHorses.getInstance(), (ScheduledTask delayed) -> {
+            if (!horse.isValid()) {
+                clear(horse);
+                return;
+            }
+
+            horse.getScheduler().runAtFixedRate(BetterHorses.getInstance(), (ScheduledTask repeating) -> {
                 if (!horse.isValid()) {
                     clear(horse);
+                    repeating.cancel();
                     return;
                 }
 
-                // Wait for landing
-                new BukkitRunnable() {
-                    @Override
-                    public void run() {
-                        if (!horse.isValid()) {
-                            clear(horse);
-                            cancel();
-                            return;
-                        }
-
-                        if (horse.isOnGround()) {
-                            if (!horse.getPassengers().isEmpty()) {
-                                Entity rider = horse.getPassengers().get(0);
-                                if (rider instanceof Player player) {
-                                    TraitRegistry.activateSkyburst(player, horse);
-                                }
-                            }
-                            clear(horse);
-                            cancel();
+                if (horse.isOnGround()) {
+                    if (!horse.getPassengers().isEmpty()) {
+                        Entity rider = horse.getPassengers().get(0);
+                        if (rider instanceof Player player) {
+                            TraitRegistry.activateSkyburst(player, horse);
                         }
                     }
-                }.runTaskTimer(BetterHorses.getInstance(), 0L, 2L);
-            }
-        }.runTaskLater(BetterHorses.getInstance(), 1L);
+                    clear(horse);
+                    repeating.cancel();
+                }
+            }, () -> {}, 0L, 2L);
+        }, () -> {}, 1L);
     }
 
     private void clear(Horse horse) {

--- a/BetterHorses/src/main/java/me/luisgamedev/traits/TraitRegistry.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/traits/TraitRegistry.java
@@ -15,8 +15,8 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -44,48 +44,44 @@ public class TraitRegistry {
 
         setCooldown(horse, key, config.getInt("traits.hellmare.cooldown", 30));
 
-        new BukkitRunnable() {
-            int ticks = 0;
+        final int[] ticks = {0};
+        horse.getScheduler().runAtFixedRate(BetterHorses.getInstance(), (ScheduledTask task) -> {
+            if (!horse.isValid()) {
+                task.cancel();
+                return;
+            }
 
-            @Override
-            public void run() {
-                if (!horse.isValid()) {
-                    cancel();
-                    return;
-                }
+            Location center = horse.getLocation().clone().subtract(0, 1, 0);
+            World world = center.getWorld();
 
-                Location center = horse.getLocation().clone().subtract(0, 1, 0);
-                World world = center.getWorld();
+            world.spawnParticle(Particle.FLAME, horse.getLocation(), 10, 0.4, 0.2, 0.4, 0.01);
 
-                world.spawnParticle(Particle.FLAME, horse.getLocation(), 10, 0.4, 0.2, 0.4, 0.01);
+            for (int dx = -radius; dx <= radius; dx++) {
+                for (int dz = -radius; dz <= radius; dz++) {
+                    Location fireLoc = center.clone().add(dx, 0, dz);
+                    Block ground = fireLoc.getBlock();
+                    Block above = ground.getRelative(0, 1, 0);
 
-                for (int dx = -radius; dx <= radius; dx++) {
-                    for (int dz = -radius; dz <= radius; dz++) {
-                        Location fireLoc = center.clone().add(dx, 0, dz);
-                        Block ground = fireLoc.getBlock();
-                        Block above = ground.getRelative(0, 1, 0);
+                    if (ground.getType().isSolid() && above.getType() == Material.AIR) {
+                        BlockIgniteEvent igniteEvent = new BlockIgniteEvent(
+                                above,
+                                BlockIgniteEvent.IgniteCause.FLINT_AND_STEEL,
+                                player
+                        );
+                        Bukkit.getPluginManager().callEvent(igniteEvent);
 
-                        if (ground.getType().isSolid() && above.getType() == Material.AIR) {
-                            BlockIgniteEvent igniteEvent = new BlockIgniteEvent(
-                                    above,
-                                    BlockIgniteEvent.IgniteCause.FLINT_AND_STEEL,
-                                    player
-                            );
-                            Bukkit.getPluginManager().callEvent(igniteEvent);
-
-                            if (!igniteEvent.isCancelled()) {
-                                above.setType(Material.FIRE);
-                            }
+                        if (!igniteEvent.isCancelled()) {
+                            above.setType(Material.FIRE);
                         }
                     }
                 }
-
-                ticks++;
-                if (ticks >= duration * 20 / 5) {
-                    cancel();
-                }
             }
-        }.runTaskTimer(BetterHorses.getInstance(), 0, 5);
+
+            ticks[0]++;
+            if (ticks[0] >= duration * 20 / 5) {
+                task.cancel();
+            }
+        }, () -> {}, 0L, 5L);
     }
 
     public static void activateFireheart(Player player, Horse horse) {
@@ -110,14 +106,11 @@ public class TraitRegistry {
 
         setCooldown(horse, key, config.getInt("traits.dashboost.cooldown", 30));
 
-        new BukkitRunnable() {
-            @Override
-            public void run() {
-                if (horse.isValid()) {
-                    horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED).setBaseValue(originalSpeed);
-                }
+        horse.getScheduler().runDelayed(BetterHorses.getInstance(), (ScheduledTask task) -> {
+            if (horse.isValid()) {
+                horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED).setBaseValue(originalSpeed);
             }
-        }.runTaskLater(BetterHorses.getInstance(), duration * 20L);
+        }, () -> {}, duration * 20L);
     }
 
     public static void activateFeatherHooves(Player player, Horse horse) {
@@ -140,16 +133,13 @@ public class TraitRegistry {
         player.setInvisible(true);
         ArmorHider.hide(player, horse);
 
-        new BukkitRunnable() {
-            @Override
-            public void run() {
-                if (horse.isValid()) {
-                    player.setInvisible(false);
-                    horse.setInvisible(false);
-                    ArmorHider.show(player, horse);
-                }
+        horse.getScheduler().runDelayed(BetterHorses.getInstance(), (ScheduledTask task) -> {
+            if (horse.isValid()) {
+                player.setInvisible(false);
+                horse.setInvisible(false);
+                ArmorHider.show(player, horse);
             }
-        }.runTaskLater(BetterHorses.getInstance(), duration * 20L);
+        }, () -> {}, duration * 20L);
 
         setCooldown(horse, key, config.getInt("traits.ghosthorse.cooldown", 30));
     }


### PR DESCRIPTION
## Summary
- switch build to dev.folia:folia-api
- replace Bukkit scheduler calls with Folia region/entity scheduler
- add missing Folia scheduler cancellation callbacks

## Testing
- `./gradlew build` *(fails: Could not resolve dev.folia:folia-api or ProtocolLib, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689d08d0fa60832b8ce404612a3c98b9