### PR TITLE
Fix dash boost speed stacking on despawn

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/DespawnCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/DespawnCommand.java
@@ -2,6 +2,7 @@ package me.luisgamedev.betterhorses.commands;
 
 import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.language.LanguageManager;
+import me.luisgamedev.betterhorses.traits.TraitRegistry;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.attribute.Attribute;
@@ -60,6 +61,8 @@ public class DespawnCommand {
         }
 
         String genderSymbol = gender.equalsIgnoreCase("male") ? lang.getRaw("messages.gender-male") : gender.equalsIgnoreCase("female") ? lang.getRaw("messages.gender-female") : "?";
+
+        TraitRegistry.revertDashBoostIfActive(horse);
 
         double maxHealth = horse.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue();
         double currentHealth = horse.getHealth();


### PR DESCRIPTION
## Summary
- store the dash boost trait's original movement speed and restore it when the boost expires
- reset the stored boost data when despawning a horse so respawns use the normal speed

## Testing
- ./gradlew check *(fails: dependency repositories return HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68da43ceecf4832b912dc2d961e084a1