### PR TITLE
Add mounted damage boost feature and conditional listener registration

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/MountedDamageBoostListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/MountedDamageBoostListener.java
@@ -1,0 +1,31 @@
+package me.luisgamedev.betterhorses.listeners;
+
+import me.luisgamedev.betterhorses.BetterHorses;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Horse;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+
+public class MountedDamageBoostListener implements Listener {
+
+    @EventHandler
+    public void onMountedDamage(EntityDamageByEntityEvent event) {
+        Entity damager = event.getDamager();
+        if (!(damager instanceof Player player)) return;
+
+        Entity vehicle = player.getVehicle();
+        if (!(vehicle instanceof Horse)) return;
+
+        FileConfiguration config = BetterHorses.getInstance().getConfig();
+        double percentage = config.getDouble("settings.mounted-damage-boost.percentage", 0.0);
+        if (percentage == 0) {
+            return;
+        }
+
+        double multiplier = 1 + (percentage / 100.0);
+        event.setDamage(event.getDamage() * multiplier);
+    }
+}

--- a/BetterHorses/src/main/resources/config.yml
+++ b/BetterHorses/src/main/resources/config.yml
@@ -50,6 +50,11 @@ settings:
   # because it exceeds their 1-block step height, only applies to mounted horses
   fix-step-height: true
 
+  # Increases player melee damage by the given percentage while riding a horse
+  mounted-damage-boost:
+    enabled: false
+    percentage: 25.0 # 25% more damage while mounted
+
   # Traited horses will have particles around them, disabling this will result in slightly better performance
   trait-particle-indicator: true
 


### PR DESCRIPTION
## Summary
- add a mounted damage boost listener that multiplies player damage while riding according to the config
- extend the default configuration with a disabled-by-default mounted damage boost section
- only register listeners whose features are enabled in the configuration to avoid unnecessary event hooks

## Testing
- `./gradlew build` *(fails: repository access to PaperMC/ProtocolLib is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc37b8ad24832ba74852d7a6cd3fb7