### PR TITLE
Refresh horse command aliases in command map

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
@@ -12,9 +12,11 @@ import me.luisgamedev.betterhorses.listeners.*;
 import me.luisgamedev.betterhorses.tasks.TraitParticleTask;
 import org.bukkit.Bukkit;
 import org.bukkit.command.PluginCommand;
+import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.PluginManager;
+import org.bukkit.craftbukkit.CraftServer;
 
 import java.util.List;
 
@@ -87,6 +89,11 @@ public class BetterHorses extends JavaPlugin {
         }
         List<String> aliases = getConfig().getStringList("command-aliases");
         horseCommand.setAliases(aliases);
+
+        CraftServer craftServer = (CraftServer) Bukkit.getServer();
+        SimpleCommandMap commandMap = craftServer.getCommandMap();
+        horseCommand.unregister(commandMap);
+        commandMap.register(getDescription().getName(), horseCommand);
     }
 
     private void registerListeners() {


### PR DESCRIPTION
## Summary
- retrieve the CraftServer command map after updating the horse command aliases
- unregister and re-register the horse command so the refreshed aliases are applied

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd2434800c832b8ad239ee4086995f