### PR TITLE
Add mount-specific settings and growth toggles

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/DespawnCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/DespawnCommand.java
@@ -3,6 +3,7 @@ package me.luisgamedev.betterhorses.commands;
 import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.language.LanguageManager;
 import me.luisgamedev.betterhorses.traits.TraitRegistry;
+import me.luisgamedev.betterhorses.utils.MountConfig;
 import me.luisgamedev.betterhorses.utils.SupportedMountType;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -66,7 +67,7 @@ public class DespawnCommand {
         Long cooldown = data.has(cooldownKey, PersistentDataType.LONG) ? data.get(cooldownKey, PersistentDataType.LONG) : null;
 
         int growthStage;
-        if (BetterHorses.getInstance().getConfig().getBoolean("horse-growth-settings.enabled")) {
+        if (MountConfig.isGrowthEnabled(BetterHorses.getInstance().getConfig(), mountType)) {
             growthStage = data.has(growthKey, PersistentDataType.INTEGER) ? data.get(growthKey, PersistentDataType.INTEGER) : 10;
         } else {
             growthStage = 10;

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/RespawnCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/RespawnCommand.java
@@ -2,6 +2,7 @@ package me.luisgamedev.betterhorses.commands;
 
 import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.language.LanguageManager;
+import me.luisgamedev.betterhorses.utils.MountConfig;
 import me.luisgamedev.betterhorses.utils.SupportedMountType;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -60,8 +61,7 @@ public class RespawnCommand {
             return true;
         }
 
-        SupportedMountType mountType = SupportedMountType.fromName(mountTypeName)
-                .orElse(SupportedMountType.HORSE);
+        SupportedMountType mountType = SupportedMountType.fromNameOrDefault(mountTypeName);
 
         if (!mountType.isEnabled(BetterHorses.getInstance().getConfig())) {
             player.sendMessage(lang.get("messages.invalid-horse-data"));
@@ -87,7 +87,7 @@ public class RespawnCommand {
         float minScale = (growthStage >= threshold) ? 0.85f : 0.7f;
         double scale = minScale + ((maxScale - minScale) / 10.0) * growthStage;
 
-        if (BetterHorses.getInstance().getConfig().getBoolean("horse-growth-settings.enabled")) {
+        if (MountConfig.isGrowthEnabled(BetterHorses.getInstance().getConfig(), mountType)) {
             setAttribute(horse, Attribute.valueOf("SCALE"), scale);
             if (growthStage >= threshold) {
                 horse.setAdult();

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseBreedListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseBreedListener.java
@@ -1,18 +1,20 @@
 package me.luisgamedev.betterhorses.listeners;
 
 import me.luisgamedev.betterhorses.BetterHorses;
+import me.luisgamedev.betterhorses.utils.MountConfig;
+import me.luisgamedev.betterhorses.utils.SupportedMountType;
+import org.bukkit.NamespacedKey;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.entity.Horse;
+import org.bukkit.entity.AbstractHorse;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityBreedEvent;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.NamespacedKey;
 
 import java.util.Set;
 
@@ -26,11 +28,20 @@ public class HorseBreedListener implements Listener {
 
     @EventHandler
     public void onHorseBreed(EntityBreedEvent event) {
-        if (!(event.getEntity() instanceof Horse child)) return;
-        if (!(event.getFather() instanceof Horse father)) return;
-        if (!(event.getMother() instanceof Horse mother)) return;
+        if (!(event.getEntity() instanceof AbstractHorse child)) return;
+        if (!(event.getFather() instanceof AbstractHorse father)) return;
+        if (!(event.getMother() instanceof AbstractHorse mother)) return;
+
+        SupportedMountType childType = SupportedMountType.fromEntity(child).orElse(null);
+        SupportedMountType fatherType = SupportedMountType.fromEntity(father).orElse(null);
+        SupportedMountType motherType = SupportedMountType.fromEntity(mother).orElse(null);
 
         FileConfiguration config = BetterHorses.getInstance().getConfig();
+
+        if (childType == null || fatherType == null || motherType == null) return;
+        if (!childType.equals(fatherType) || !childType.equals(motherType)) return;
+        if (!childType.isEnabled(config)) return;
+
         long cooldownSeconds = config.getLong("settings.breeding-cooldown", 0);
         long cooldownMillis = cooldownSeconds * 1000L;
         long now = System.currentTimeMillis();
@@ -73,12 +84,12 @@ public class HorseBreedListener implements Listener {
             return;
         }
 
-        double mutationHealth = config.getDouble("mutation-factor.health");
-        double mutationSpeed = config.getDouble("mutation-factor.speed");
-        double mutationJump = config.getDouble("mutation-factor.jump");
-        double maxHealth = config.getDouble("max-stats.health");
-        double maxSpeed = config.getDouble("max-stats.speed");
-        double maxJump = config.getDouble("max-stats.jump");
+        double mutationHealth = MountConfig.getMutationFactor(config, childType, "health");
+        double mutationSpeed = MountConfig.getMutationFactor(config, childType, "speed");
+        double mutationJump = MountConfig.getMutationFactor(config, childType, "jump");
+        double maxHealth = MountConfig.getMaxStat(config, childType, "health");
+        double maxSpeed = MountConfig.getMaxStat(config, childType, "speed");
+        double maxJump = MountConfig.getMaxStat(config, childType, "jump");
 
         double childHealth = mutate(avg(getHealth(father), getHealth(mother)), mutationHealth, maxHealth);
         double childSpeed = mutate(avg(getSpeed(father), getSpeed(mother)), mutationSpeed, maxSpeed);
@@ -92,7 +103,7 @@ public class HorseBreedListener implements Listener {
         child.getPersistentDataContainer().set(genderKey, PersistentDataType.STRING, gender);
         child.getPersistentDataContainer().set(growthKey, PersistentDataType.INTEGER, 1);
 
-        if (config.getBoolean("horse-growth-settings.enabled")) {
+        if (MountConfig.isGrowthEnabled(config, childType)) {
             child.setAgeLock(true);
         }
 
@@ -123,7 +134,7 @@ public class HorseBreedListener implements Listener {
         mother.setAge(0);
     }
 
-    private String getGender(Horse horse) {
+    private String getGender(AbstractHorse horse) {
         PersistentDataContainer data = horse.getPersistentDataContainer();
         if (!data.has(genderKey, PersistentDataType.STRING)) {
             String gender = Math.random() < 0.5 ? "male" : "female";
@@ -133,7 +144,7 @@ public class HorseBreedListener implements Listener {
         return data.getOrDefault(genderKey, PersistentDataType.STRING, "unknown");
     }
 
-    private boolean isNeutered(Horse horse) {
+    private boolean isNeutered(AbstractHorse horse) {
         PersistentDataContainer data = horse.getPersistentDataContainer();
         return data.has(neuterKey, PersistentDataType.BYTE) && data.get(neuterKey, PersistentDataType.BYTE) == (byte) 1;
     }
@@ -147,29 +158,40 @@ public class HorseBreedListener implements Listener {
         return Math.min(base + mutation, max);
     }
 
-    private double getHealth(Horse horse) {
-        return horse.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue();
+    private double getHealth(AbstractHorse horse) {
+        AttributeInstance attribute = horse.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+        return attribute != null ? attribute.getBaseValue() : 0.0;
     }
 
-    private double getSpeed(Horse horse) {
-        return horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED).getBaseValue();
+    private double getSpeed(AbstractHorse horse) {
+        AttributeInstance attribute = horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+        return attribute != null ? attribute.getBaseValue() : 0.0;
     }
 
-    private double getJump(Horse horse) {
-        return horse.getAttribute(Attribute.valueOf("HORSE_JUMP_STRENGTH")).getBaseValue();
+    private double getJump(AbstractHorse horse) {
+        AttributeInstance attribute = horse.getAttribute(Attribute.valueOf("HORSE_JUMP_STRENGTH"));
+        return attribute != null ? attribute.getBaseValue() : 0.0;
     }
 
-    private void setHealth(Horse horse, double value) {
+    private void setHealth(AbstractHorse horse, double value) {
         AttributeInstance attr = horse.getAttribute(Attribute.GENERIC_MAX_HEALTH);
-        attr.setBaseValue(value);
+        if (attr != null) {
+            attr.setBaseValue(value);
+        }
         horse.setHealth(value);
     }
 
-    private void setSpeed(Horse horse, double value) {
-        horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED).setBaseValue(value);
+    private void setSpeed(AbstractHorse horse, double value) {
+        AttributeInstance attribute = horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+        if (attribute != null) {
+            attribute.setBaseValue(value);
+        }
     }
 
-    private void setJump(Horse horse, double value) {
-        horse.getAttribute(Attribute.valueOf("HORSE_JUMP_STRENGTH")).setBaseValue(value);
+    private void setJump(AbstractHorse horse, double value) {
+        AttributeInstance attribute = horse.getAttribute(Attribute.valueOf("HORSE_JUMP_STRENGTH"));
+        if (attribute != null) {
+            attribute.setBaseValue(value);
+        }
     }
 }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseSpawnListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseSpawnListener.java
@@ -1,17 +1,18 @@
 package me.luisgamedev.betterhorses.listeners;
 
 import me.luisgamedev.betterhorses.BetterHorses;
+import me.luisgamedev.betterhorses.utils.MountConfig;
+import me.luisgamedev.betterhorses.utils.SupportedMountType;
+import org.bukkit.NamespacedKey;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Horse;
+import org.bukkit.entity.AbstractHorse;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.NamespacedKey;
 
 import java.util.Random;
 
@@ -24,10 +25,10 @@ public class HorseSpawnListener implements Listener {
 
     @EventHandler
     public void onHorseSpawn(CreatureSpawnEvent event) {
-        if (event.getEntityType() != EntityType.HORSE) return;
+        if (!(event.getEntity() instanceof AbstractHorse horse)) return;
+        SupportedMountType mountType = SupportedMountType.fromEntity(horse).orElse(null);
+        if (mountType == null || !mountType.isEnabled(BetterHorses.getInstance().getConfig())) return;
         if (event.getSpawnReason() != CreatureSpawnEvent.SpawnReason.NATURAL) return;
-
-        Horse horse = (Horse) event.getEntity();
 
         // Set gender
         String gender = GENDERS[random.nextInt(GENDERS.length)];
@@ -37,7 +38,7 @@ public class HorseSpawnListener implements Listener {
         int stage = 10;
 
         //if (BetterHorses.getInstance().getConfig().getBoolean("horse-growth-settings.enabled")) {
-        boolean growthEnabled = BetterHorses.getInstance().getConfig().getBoolean("horse-growth-settings.enabled");
+        boolean growthEnabled = MountConfig.isGrowthEnabled(BetterHorses.getInstance().getConfig(), mountType);
         if (growthEnabled) {
             // Set random growth stage
             stage = random.nextInt(11); // 0–10

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RightClickListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RightClickListener.java
@@ -2,6 +2,7 @@ package me.luisgamedev.betterhorses.listeners;
 
 import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.language.LanguageManager;
+import me.luisgamedev.betterhorses.utils.MountConfig;
 import me.luisgamedev.betterhorses.utils.SupportedMountType;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -74,8 +75,7 @@ public class RightClickListener implements Listener {
             return;
         }
 
-        SupportedMountType mountType = SupportedMountType.fromName(mountTypeName)
-                .orElse(SupportedMountType.HORSE);
+        SupportedMountType mountType = SupportedMountType.fromNameOrDefault(mountTypeName);
 
         if (!mountType.isEnabled(config)) {
             player.sendMessage(lang.get("messages.invalid-horse-data"));
@@ -100,7 +100,7 @@ public class RightClickListener implements Listener {
         float minScale = (growthStage >= threshold) ? 0.85f : 0.7f;
         double scale = minScale + ((maxScale - minScale) / 10.0) * growthStage;
 
-        if (config.getBoolean("horse-growth-settings.enabled")) {
+        if (MountConfig.isGrowthEnabled(config, mountType)) {
             setAttribute(horse, Attribute.valueOf("SCALE"), scale);
             if (growthStage >= threshold) {
                 horse.setAdult();

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/MountConfig.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/MountConfig.java
@@ -1,0 +1,36 @@
+package me.luisgamedev.betterhorses.utils;
+
+import org.bukkit.configuration.file.FileConfiguration;
+
+public final class MountConfig {
+
+    private MountConfig() {}
+
+    public static double getMutationFactor(FileConfiguration config, SupportedMountType mountType, String attribute) {
+        String overridePath = "mutation-factor." + mountType.getConfigKey() + "." + attribute;
+        String basePath = "mutation-factor." + attribute;
+        if (config.contains(overridePath)) {
+            return config.getDouble(overridePath);
+        }
+        return config.getDouble(basePath);
+    }
+
+    public static double getMaxStat(FileConfiguration config, SupportedMountType mountType, String attribute) {
+        String overridePath = "max-stats." + mountType.getConfigKey() + "." + attribute;
+        String basePath = "max-stats." + attribute;
+        if (config.contains(overridePath)) {
+            return config.getDouble(overridePath);
+        }
+        return config.getDouble(basePath);
+    }
+
+    public static boolean isGrowthEnabled(FileConfiguration config, SupportedMountType mountType) {
+        if (!config.getBoolean("horse-growth-settings.enabled")) {
+            return false;
+        }
+        if (mountType == SupportedMountType.HORSE) {
+            return true;
+        }
+        return config.getBoolean("horse-growth-settings.mount-types." + mountType.getConfigKey() + ".enabled", true);
+    }
+}

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/SupportedMountType.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/SupportedMountType.java
@@ -68,6 +68,10 @@ public enum SupportedMountType {
         }
     }
 
+    public static SupportedMountType fromNameOrDefault(String name) {
+        return fromName(name).orElse(SupportedMountType.HORSE);
+    }
+
     public static boolean isSupported(Entity entity) {
         return fromEntity(entity)
                 .map(type -> type.isEnabled(BetterHorses.getInstance().getConfig()))

--- a/BetterHorses/src/main/resources/config.yml
+++ b/BetterHorses/src/main/resources/config.yml
@@ -11,18 +11,46 @@ mutation-factor:
   health: 3.0
   speed: 0.05
   jump: 0.05
+  skeleton-horses:
+    health: 3.0
+    speed: 0.05
+    jump: 0.05
+  zombie-horses:
+    health: 3.0
+    speed: 0.05
+    jump: 0.05
+  camels:
+    health: 3.0
+    speed: 0.05
+    jump: 0.05
 
 # Max stats a horse can reach
 max-stats:
   health: 300.0
   speed: 0.4
   jump: 1.2
+  skeleton-horses:
+    health: 300.0
+    speed: 0.4
+    jump: 1.2
+  zombie-horses:
+    health: 300.0
+    speed: 0.4
+    jump: 1.2
+  camels:
+    health: 300.0
+    speed: 0.4
+    jump: 1.2
 
 # Settings that determine horse growth
 horse-growth-settings:
 
   # If false, horses will remain their Vanilla size, this feature only works for Paper 1.20.6 & Java 21 or above
   enabled: true
+  mount-types:
+    skeleton-horses: true
+    zombie-horses: true
+    camels: true
 
   # The time in minutes that needs to pass until a horse is fully grown
   time-until-adult: 3


### PR DESCRIPTION
## Summary
- add mount configuration helper and default mount-type fallback to keep legacy horse items spawning correctly
- respect mount-type specific growth toggles and stat/mutation overrides across spawning, breeding, despawning, and the growth manager
- extend the default config with per-mount mutation factors, max stats, and growth enable switches for skeleton, zombie, and camel mounts

## Testing
- ./gradlew test *(fails: unable to download Paper API and ProtocolLib dependencies due to 403 responses from remote repositories)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e8d941928832bb9330a32f6ab054e)