### PR TITLE
Handle dash boost revert for abstract horses

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/traits/TraitRegistry.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/traits/TraitRegistry.java
@@ -171,7 +171,7 @@ public class TraitRegistry {
         }.runTaskLater(BetterHorses.getInstance(), duration * 20L);
     }
 
-    public static void revertDashBoostIfActive(Horse horse) {
+    public static void revertDashBoostIfActive(AbstractHorse horse) {
         if (horse == null) return;
 
         Double storedOriginal = dashBoostOriginalSpeeds.remove(horse.getUniqueId());


### PR DESCRIPTION
## Summary
- allow dash boost revert logic to work with any AbstractHorse to avoid class cast issues during despawn

## Testing
- ./gradlew test (fails: dependency downloads blocked with 403 responses)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e910984e8832bb9a8dcab2ec215fb)