### PR TITLE
Handle null owners when despawning mounts

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/DespawnCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/DespawnCommand.java
@@ -10,6 +10,7 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.AbstractHorse;
+import org.bukkit.entity.AnimalTamer;
 import org.bukkit.entity.Horse;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.AbstractHorseInventory;
@@ -42,7 +43,8 @@ public class DespawnCommand {
             return true;
         }
 
-        if (!horse.isTamed() || !horse.getOwner().getUniqueId().equals(player.getUniqueId())) {
+        AnimalTamer owner = horse.getOwner();
+        if (!horse.isTamed() || owner == null || !owner.getUniqueId().equals(player.getUniqueId())) {
             player.sendMessage(lang.get("messages.not-horse-owner"));
             return true;
         }


### PR DESCRIPTION
## Summary
- avoid dereferencing a null owner when despawning mounts like camels
- maintain ownership validation before converting mounts to items

## Testing
- ./gradlew test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e9cc796ac832b80a3fdde0370bce2)