### PR TITLE
Add developer API events and utilities for BetterHorses

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorse.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorse.java
@@ -1,0 +1,84 @@
+package me.luisgamedev.betterhorses.api;
+
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.entity.AbstractHorse;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.util.Optional;
+
+/**
+ * Wrapper around an in-world BetterHorses mount to simplify reading and
+ * writing its custom stats while keeping persistent data synchronized.
+ */
+public final class BetterHorse {
+
+    private final AbstractHorse handle;
+
+    public BetterHorse(AbstractHorse handle) {
+        this.handle = handle;
+    }
+
+    public AbstractHorse getHandle() {
+        return handle;
+    }
+
+    public double getMaxHealth() {
+        AttributeInstance attr = handle.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+        return attr != null ? attr.getBaseValue() : 0.0;
+    }
+
+    public void setMaxHealth(double value) {
+        setAttribute(Attribute.GENERIC_MAX_HEALTH, BetterHorseKeys.HEALTH, value);
+    }
+
+    public double getSpeed() {
+        AttributeInstance attr = handle.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+        return attr != null ? attr.getBaseValue() : 0.0;
+    }
+
+    public void setSpeed(double value) {
+        setAttribute(Attribute.GENERIC_MOVEMENT_SPEED, BetterHorseKeys.SPEED, value);
+    }
+
+    public double getJump() {
+        AttributeInstance attr = handle.getAttribute(Attribute.valueOf("HORSE_JUMP_STRENGTH"));
+        return attr != null ? attr.getBaseValue() : 0.0;
+    }
+
+    public void setJump(double value) {
+        setAttribute(Attribute.valueOf("HORSE_JUMP_STRENGTH"), BetterHorseKeys.JUMP, value);
+    }
+
+    public Optional<String> getTrait() {
+        PersistentDataContainer data = handle.getPersistentDataContainer();
+        return Optional.ofNullable(data.get(BetterHorseKeys.TRAIT, PersistentDataType.STRING));
+    }
+
+    public void setTrait(String trait) {
+        PersistentDataContainer data = handle.getPersistentDataContainer();
+        if (trait == null || trait.isBlank()) {
+            data.remove(BetterHorseKeys.TRAIT);
+        } else {
+            data.set(BetterHorseKeys.TRAIT, PersistentDataType.STRING, trait.toLowerCase());
+        }
+    }
+
+    public Optional<Integer> getGrowthStage() {
+        PersistentDataContainer data = handle.getPersistentDataContainer();
+        return Optional.ofNullable(data.get(BetterHorseKeys.GROWTH_STAGE, PersistentDataType.INTEGER));
+    }
+
+    public void setGrowthStage(int stage) {
+        handle.getPersistentDataContainer().set(BetterHorseKeys.GROWTH_STAGE, PersistentDataType.INTEGER, stage);
+    }
+
+    private void setAttribute(Attribute attribute, org.bukkit.NamespacedKey key, double value) {
+        AttributeInstance attr = handle.getAttribute(attribute);
+        if (attr != null) {
+            attr.setBaseValue(value);
+        }
+        handle.getPersistentDataContainer().set(key, PersistentDataType.DOUBLE, value);
+    }
+}

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorseItem.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorseItem.java
@@ -1,0 +1,48 @@
+package me.luisgamedev.betterhorses.api;
+
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.util.Optional;
+
+/**
+ * Wrapper around a BetterHorses item to make reading custom metadata easier.
+ */
+public final class BetterHorseItem {
+
+    private final ItemStack itemStack;
+
+    public BetterHorseItem(ItemStack itemStack) {
+        this.itemStack = itemStack;
+    }
+
+    public ItemStack getHandle() {
+        return itemStack;
+    }
+
+    public Optional<Double> getHealth() {
+        return getDouble(BetterHorseKeys.HEALTH);
+    }
+
+    public Optional<Double> getSpeed() {
+        return getDouble(BetterHorseKeys.SPEED);
+    }
+
+    public Optional<Double> getJump() {
+        return getDouble(BetterHorseKeys.JUMP);
+    }
+
+    public Optional<String> getMountType() {
+        ItemMeta meta = itemStack.getItemMeta();
+        PersistentDataContainer data = meta.getPersistentDataContainer();
+        return Optional.ofNullable(data.get(BetterHorseKeys.MOUNT_TYPE, PersistentDataType.STRING));
+    }
+
+    private Optional<Double> getDouble(org.bukkit.NamespacedKey key) {
+        ItemMeta meta = itemStack.getItemMeta();
+        PersistentDataContainer data = meta.getPersistentDataContainer();
+        return Optional.ofNullable(data.get(key, PersistentDataType.DOUBLE));
+    }
+}

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorseKeys.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorseKeys.java
@@ -1,0 +1,36 @@
+package me.luisgamedev.betterhorses.api;
+
+import me.luisgamedev.betterhorses.BetterHorses;
+import org.bukkit.NamespacedKey;
+
+/**
+ * Centralizes the namespaced keys used by BetterHorses to store metadata on
+ * entities and items. These keys are stable to ensure backwards compatibility
+ * for horses created with previous versions of the plugin.
+ */
+public final class BetterHorseKeys {
+
+    private BetterHorseKeys() {
+    }
+
+    public static final NamespacedKey GENDER = key("gender");
+    public static final NamespacedKey CURRENT_HEALTH = key("current_health");
+    public static final NamespacedKey HEALTH = key("health");
+    public static final NamespacedKey SPEED = key("speed");
+    public static final NamespacedKey JUMP = key("jump");
+    public static final NamespacedKey OWNER = key("owner");
+    public static final NamespacedKey NAME = key("name");
+    public static final NamespacedKey STYLE = key("style");
+    public static final NamespacedKey COLOR = key("color");
+    public static final NamespacedKey GROWTH_STAGE = key("growth_stage");
+    public static final NamespacedKey MOUNT_TYPE = key("mount_type");
+    public static final NamespacedKey TRAIT = key("trait");
+    public static final NamespacedKey NEUTERED = key("neutered");
+    public static final NamespacedKey COOLDOWN = key("cooldown");
+    public static final NamespacedKey SADDLE = key("saddle");
+    public static final NamespacedKey ARMOR = key("armor");
+
+    private static NamespacedKey key(String key) {
+        return new NamespacedKey(BetterHorses.getInstance(), key);
+    }
+}

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/events/BetterHorseDespawnEvent.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/events/BetterHorseDespawnEvent.java
@@ -1,0 +1,57 @@
+package me.luisgamedev.betterhorses.api.events;
+
+import org.bukkit.entity.AbstractHorse;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Fired whenever a BetterHorses mount is converted back into an item.
+ */
+public class BetterHorseDespawnEvent extends Event implements Cancellable {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final AbstractHorse horse;
+    private final ItemStack resultItem;
+    private boolean cancelled;
+
+    public BetterHorseDespawnEvent(@NotNull AbstractHorse horse, @Nullable ItemStack resultItem) {
+        this.horse = horse;
+        this.resultItem = resultItem;
+    }
+
+    public @NotNull AbstractHorse getHorse() {
+        return horse;
+    }
+
+    /**
+        * Item stack that will be given to the player. May be null if the horse
+        * was not yet converted to an item when the event is fired.
+        */
+    public @Nullable ItemStack getResultItem() {
+        return resultItem;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/events/BetterHorseSpawnEvent.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/events/BetterHorseSpawnEvent.java
@@ -1,0 +1,65 @@
+package me.luisgamedev.betterhorses.api.events;
+
+import org.bukkit.entity.AbstractHorse;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Fired whenever a BetterHorses mount is spawned, either from an item or a
+ * natural spawn handled by the plugin.
+ */
+public class BetterHorseSpawnEvent extends Event implements Cancellable {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    public enum SpawnCause {
+        ITEM,
+        NATURAL
+    }
+
+    private final AbstractHorse horse;
+    private final SpawnCause cause;
+    private final ItemStack sourceItem;
+    private boolean cancelled;
+
+    public BetterHorseSpawnEvent(@NotNull AbstractHorse horse, @Nullable ItemStack sourceItem, @NotNull SpawnCause cause) {
+        this.horse = horse;
+        this.cause = cause;
+        this.sourceItem = sourceItem;
+    }
+
+    public @NotNull AbstractHorse getHorse() {
+        return horse;
+    }
+
+    public @NotNull SpawnCause getCause() {
+        return cause;
+    }
+
+    public @Nullable ItemStack getSourceItem() {
+        return sourceItem;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/DespawnCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/DespawnCommand.java
@@ -1,6 +1,7 @@
 package me.luisgamedev.betterhorses.commands;
 
 import me.luisgamedev.betterhorses.BetterHorses;
+import me.luisgamedev.betterhorses.api.BetterHorsesAPI;
 import me.luisgamedev.betterhorses.language.LanguageManager;
 import me.luisgamedev.betterhorses.traits.TraitRegistry;
 import me.luisgamedev.betterhorses.utils.MountConfig;
@@ -158,6 +159,10 @@ public class DespawnCommand {
 
         item.setItemMeta(meta);
         boolean wasLeashed = horse.isLeashed();
+
+        if (BetterHorsesAPI.callDespawnEvent(horse, item)) {
+            return true;
+        }
 
         horse.remove();
 

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/RespawnCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/RespawnCommand.java
@@ -1,6 +1,8 @@
 package me.luisgamedev.betterhorses.commands;
 
 import me.luisgamedev.betterhorses.BetterHorses;
+import me.luisgamedev.betterhorses.api.BetterHorsesAPI;
+import me.luisgamedev.betterhorses.api.events.BetterHorseSpawnEvent;
 import me.luisgamedev.betterhorses.language.LanguageManager;
 import me.luisgamedev.betterhorses.utils.MountConfig;
 import me.luisgamedev.betterhorses.utils.SupportedMountType;
@@ -152,6 +154,7 @@ public class RespawnCommand {
         }
 
         item.setAmount(item.getAmount() - 1);
+        BetterHorsesAPI.callSpawnEvent(horse, item, BetterHorseSpawnEvent.SpawnCause.ITEM);
         player.sendMessage(lang.getFormatted("messages.horse-respawned", "%mount%", mountName));
         return true;
     }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseSpawnListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseSpawnListener.java
@@ -1,6 +1,8 @@
 package me.luisgamedev.betterhorses.listeners;
 
 import me.luisgamedev.betterhorses.BetterHorses;
+import me.luisgamedev.betterhorses.api.BetterHorsesAPI;
+import me.luisgamedev.betterhorses.api.events.BetterHorseSpawnEvent;
 import me.luisgamedev.betterhorses.utils.MountConfig;
 import me.luisgamedev.betterhorses.utils.SupportedMountType;
 import org.bukkit.NamespacedKey;
@@ -71,5 +73,6 @@ public class HorseSpawnListener implements Listener {
         }
 
         data.set(growthKey, PersistentDataType.INTEGER, stage);
+        BetterHorsesAPI.callSpawnEvent(horse, null, BetterHorseSpawnEvent.SpawnCause.NATURAL);
     }
 }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RightClickListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RightClickListener.java
@@ -1,6 +1,8 @@
 package me.luisgamedev.betterhorses.listeners;
 
 import me.luisgamedev.betterhorses.BetterHorses;
+import me.luisgamedev.betterhorses.api.BetterHorsesAPI;
+import me.luisgamedev.betterhorses.api.events.BetterHorseSpawnEvent;
 import me.luisgamedev.betterhorses.language.LanguageManager;
 import me.luisgamedev.betterhorses.utils.MountConfig;
 import me.luisgamedev.betterhorses.utils.SupportedMountType;
@@ -96,6 +98,8 @@ public class RightClickListener implements Listener {
             player.sendMessage(lang.get("messages.cant-spawn"));
             return;
         }
+
+        BetterHorsesAPI.callSpawnEvent(horse, item.clone(), BetterHorseSpawnEvent.SpawnCause.ITEM);
 
         double maxScale = config.getDouble("horse-growth-settings.max-size", 1.3);
         int threshold = config.getInt("horse-growth-settings.ride-and-breed-threshhold", 7);


### PR DESCRIPTION
## Summary
- add BetterHorse wrapper classes, keys, and item accessors for developer API usage
- introduce custom BetterHorse spawn and despawn events and dispatch them on horse lifecycle actions
- add utilities to detect BetterHorses entities/items while keeping existing mounts backward compatible

## Testing
- ./gradlew test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f1969de50832bb1b1ec8f1447620e)