### PR TITLE
Add horse lifecycle and ability events

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/events/BetterHorseAbilityUseEvent.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/events/BetterHorseAbilityUseEvent.java
@@ -1,0 +1,66 @@
+package me.luisgamedev.betterhorses.api.events;
+
+import org.bukkit.entity.Horse;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+/**
+ * Fired when a rider attempts to activate a BetterHorses trait ability (e.g.
+ * Dash Boost, Hellmare, Ghost Horse). Cancelling this event prevents the
+ * ability from running and keeps the previous cooldown state intact.
+ */
+public class BetterHorseAbilityUseEvent extends Event implements Cancellable {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final Player player;
+    private final Horse horse;
+    private String traitKey;
+    private boolean cancelled;
+
+    public BetterHorseAbilityUseEvent(@NotNull Player player, @NotNull Horse horse, @NotNull String traitKey) {
+        this.player = Objects.requireNonNull(player, "player");
+        this.horse = Objects.requireNonNull(horse, "horse");
+        this.traitKey = Objects.requireNonNull(traitKey, "traitKey");
+    }
+
+    public @NotNull Player getPlayer() {
+        return player;
+    }
+
+    public @NotNull Horse getHorse() {
+        return horse;
+    }
+
+    public @NotNull String getTraitKey() {
+        return traitKey;
+    }
+
+    public void setTraitKey(@NotNull String traitKey) {
+        this.traitKey = Objects.requireNonNull(traitKey, "traitKey");
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/events/BetterHorseBreedEvent.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/events/BetterHorseBreedEvent.java
@@ -1,0 +1,119 @@
+package me.luisgamedev.betterhorses.api.events;
+
+import org.bukkit.entity.AbstractHorse;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+/**
+ * Fired after BetterHorses calculates the stats for a newly bred foal but
+ * before they are applied. Listeners may modify the resulting stats, gender,
+ * or trait, or cancel to stop the breeding entirely.
+ */
+public class BetterHorseBreedEvent extends Event implements Cancellable {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final AbstractHorse child;
+    private final AbstractHorse father;
+    private final AbstractHorse mother;
+    private double health;
+    private double speed;
+    private double jump;
+    private String gender;
+    private @Nullable String trait;
+    private boolean cancelled;
+
+    public BetterHorseBreedEvent(@NotNull AbstractHorse child,
+                                 @NotNull AbstractHorse father,
+                                 @NotNull AbstractHorse mother,
+                                 double health,
+                                 double speed,
+                                 double jump,
+                                 @NotNull String gender,
+                                 @Nullable String trait) {
+        this.child = Objects.requireNonNull(child, "child");
+        this.father = Objects.requireNonNull(father, "father");
+        this.mother = Objects.requireNonNull(mother, "mother");
+        this.health = health;
+        this.speed = speed;
+        this.jump = jump;
+        this.gender = Objects.requireNonNull(gender, "gender");
+        this.trait = trait;
+    }
+
+    public @NotNull AbstractHorse getChild() {
+        return child;
+    }
+
+    public @NotNull AbstractHorse getFather() {
+        return father;
+    }
+
+    public @NotNull AbstractHorse getMother() {
+        return mother;
+    }
+
+    public double getHealth() {
+        return health;
+    }
+
+    public void setHealth(double health) {
+        this.health = health;
+    }
+
+    public double getSpeed() {
+        return speed;
+    }
+
+    public void setSpeed(double speed) {
+        this.speed = speed;
+    }
+
+    public double getJump() {
+        return jump;
+    }
+
+    public void setJump(double jump) {
+        this.jump = jump;
+    }
+
+    public @NotNull String getGender() {
+        return gender;
+    }
+
+    public void setGender(@NotNull String gender) {
+        this.gender = Objects.requireNonNull(gender, "gender");
+    }
+
+    public @Nullable String getTrait() {
+        return trait;
+    }
+
+    public void setTrait(@Nullable String trait) {
+        this.trait = trait;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/events/BetterHorseNeuterEvent.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/events/BetterHorseNeuterEvent.java
@@ -1,0 +1,60 @@
+package me.luisgamedev.betterhorses.api.events;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+/**
+ * Fired when a BetterHorses item is about to be neutered via the {@code /horse neuter}
+ * command. Cancelling this event will prevent the neutering from being applied to the
+ * target item.
+ */
+public class BetterHorseNeuterEvent extends Event implements Cancellable {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final Player player;
+    private ItemStack horseItem;
+    private boolean cancelled;
+
+    public BetterHorseNeuterEvent(@NotNull Player player, @NotNull ItemStack horseItem) {
+        this.player = Objects.requireNonNull(player, "player");
+        this.horseItem = Objects.requireNonNull(horseItem, "horseItem");
+    }
+
+    public @NotNull Player getPlayer() {
+        return player;
+    }
+
+    public @NotNull ItemStack getHorseItem() {
+        return horseItem;
+    }
+
+    public void setHorseItem(@NotNull ItemStack horseItem) {
+        this.horseItem = Objects.requireNonNull(horseItem, "horseItem");
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseNeuterCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseNeuterCommand.java
@@ -1,8 +1,10 @@
 package me.luisgamedev.betterhorses.commands;
 
 import me.luisgamedev.betterhorses.BetterHorses;
+import me.luisgamedev.betterhorses.api.events.BetterHorseNeuterEvent;
 import me.luisgamedev.betterhorses.language.LanguageManager;
 import org.bukkit.ChatColor;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -40,6 +42,16 @@ public class HorseNeuterCommand {
             player.sendMessage(lang.get("messages.already-castrated"));
             return true;
         }
+
+        BetterHorseNeuterEvent neuterEvent = new BetterHorseNeuterEvent(player, item.clone());
+        Bukkit.getPluginManager().callEvent(neuterEvent);
+        if (neuterEvent.isCancelled()) {
+            return true;
+        }
+
+        item = neuterEvent.getHorseItem();
+        player.getInventory().setItemInMainHand(item);
+        meta = item.getItemMeta();
 
         meta.getPersistentDataContainer().set(neuteredKey, PersistentDataType.BYTE, (byte) 1);
 

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/TraitActivationListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/TraitActivationListener.java
@@ -1,7 +1,9 @@
 package me.luisgamedev.betterhorses.listeners;
 
 import me.luisgamedev.betterhorses.BetterHorses;
+import me.luisgamedev.betterhorses.api.events.BetterHorseAbilityUseEvent;
 import me.luisgamedev.betterhorses.traits.TraitRegistry;
+import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Horse;
@@ -29,7 +31,15 @@ public class TraitActivationListener implements Listener {
         String trait = data.get(traitKey, PersistentDataType.STRING);
         if (trait == null) return;
 
-        switch (trait.toLowerCase()) {
+        BetterHorseAbilityUseEvent abilityEvent = new BetterHorseAbilityUseEvent(player, horse, trait.toLowerCase());
+        Bukkit.getPluginManager().callEvent(abilityEvent);
+        if (abilityEvent.isCancelled()) {
+            event.setCancelled(true);
+            return;
+        }
+
+        String selectedTrait = abilityEvent.getTraitKey();
+        switch (selectedTrait.toLowerCase()) {
             case "hellmare":
                 TraitRegistry.activateHellmare(player, horse);
                 break;


### PR DESCRIPTION
## Summary
- add a cancellable BetterHorseNeuterEvent that fires during /horse neuter and allows plugins to modify the target item
- fire BetterHorseAbilityUseEvent before trait activations and BetterHorseBreedEvent around child stat/gender/trait calculation for breeding
- continue using stable BetterHorseKeys when recording breeding metadata to keep existing horses compatible

## Testing
- ./gradlew test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f1e209a14832ba179cdccd4621ab5)