### PR TITLE
Extend trait abilities to all supported mounts

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/events/BetterHorseAbilityUseEvent.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/events/BetterHorseAbilityUseEvent.java
@@ -1,5 +1,6 @@
 package me.luisgamedev.betterhorses.api.events;
 
+import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.Horse;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
@@ -19,13 +20,17 @@ public class BetterHorseAbilityUseEvent extends Event implements Cancellable {
     private static final HandlerList HANDLERS = new HandlerList();
 
     private final Player player;
-    private final Horse horse;
+    private final AbstractHorse mount;
     private String traitKey;
     private boolean cancelled;
 
     public BetterHorseAbilityUseEvent(@NotNull Player player, @NotNull Horse horse, @NotNull String traitKey) {
+        this(player, (AbstractHorse) horse, traitKey);
+    }
+
+    public BetterHorseAbilityUseEvent(@NotNull Player player, @NotNull AbstractHorse mount, @NotNull String traitKey) {
         this.player = Objects.requireNonNull(player, "player");
-        this.horse = Objects.requireNonNull(horse, "horse");
+        this.mount = Objects.requireNonNull(mount, "mount");
         this.traitKey = Objects.requireNonNull(traitKey, "traitKey");
     }
 
@@ -33,8 +38,15 @@ public class BetterHorseAbilityUseEvent extends Event implements Cancellable {
         return player;
     }
 
-    public @NotNull Horse getHorse() {
-        return horse;
+    /**
+     * @return The mount as a Horse when applicable, or {@code null} for other supported mount types.
+     */
+    public Horse getHorse() {
+        return mount instanceof Horse ? (Horse) mount : null;
+    }
+
+    public @NotNull AbstractHorse getMount() {
+        return mount;
     }
 
     public @NotNull String getTraitKey() {

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseJumpListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseJumpListener.java
@@ -3,10 +3,11 @@ package me.luisgamedev.betterhorses.listeners;
 import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.language.LanguageManager;
 import me.luisgamedev.betterhorses.traits.TraitRegistry;
+import me.luisgamedev.betterhorses.utils.SupportedMountType;
 import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.Horse;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -21,14 +22,15 @@ import java.util.Set;
 
 public class HorseJumpListener implements Listener {
 
-    private final Set<Horse> airborneHorses = new HashSet<>();
+    private final Set<AbstractHorse> airborneHorses = new HashSet<>();
     private final FileConfiguration config = BetterHorses.getInstance().getConfig();
     private final LanguageManager lang = BetterHorses.getInstance().getLang();
     private final NamespacedKey traitKey = new NamespacedKey(BetterHorses.getInstance(), "trait");
 
     @EventHandler
     public void onHorseJump(HorseJumpEvent event) {
-        if (!(event.getEntity() instanceof Horse horse)) return;
+        if (!(event.getEntity() instanceof AbstractHorse horse)) return;
+        if (!SupportedMountType.isSupported(horse)) return;
         if (hasHeavenHoovesTrait(horse)) {
             Entity rider = horse.getPassengers().get(0);
             if (rider instanceof Player player) {
@@ -75,18 +77,18 @@ public class HorseJumpListener implements Listener {
         }.runTaskLater(BetterHorses.getInstance(), 1L);
     }
 
-    private void clear(Horse horse) {
+    private void clear(AbstractHorse horse) {
         horse.removeMetadata("SkyburstCandidate", BetterHorses.getInstance());
         airborneHorses.remove(horse);
     }
 
-    private boolean hasSkyburstTrait(Horse horse) {
+    private boolean hasSkyburstTrait(AbstractHorse horse) {
         if (!horse.getPersistentDataContainer().has(traitKey, PersistentDataType.STRING)) return false;
         String trait = horse.getPersistentDataContainer().get(traitKey, PersistentDataType.STRING);
         return "skyburst".equalsIgnoreCase(trait) && config.getBoolean("traits.skyburst.enabled", true);
     }
 
-    private boolean hasHeavenHoovesTrait(Horse horse) {
+    private boolean hasHeavenHoovesTrait(AbstractHorse horse) {
         if (!horse.getPersistentDataContainer().has(traitKey, PersistentDataType.STRING)) return false;
         String trait = horse.getPersistentDataContainer().get(traitKey, PersistentDataType.STRING);
         return "heavenhooves".equalsIgnoreCase(trait) && config.getBoolean("traits.heavenhooves.enabled", true);
@@ -94,8 +96,10 @@ public class HorseJumpListener implements Listener {
 
     @EventHandler
     public void onDismount(VehicleExitEvent event) {
-        if (event.getVehicle() instanceof Horse horse) {
-            clear(horse);
+        if (event.getVehicle() instanceof AbstractHorse horse) {
+            if (SupportedMountType.isSupported(horse)) {
+                clear(horse);
+            }
         }
     }
 }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/PassiveTraitListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/PassiveTraitListener.java
@@ -2,8 +2,9 @@ package me.luisgamedev.betterhorses.listeners;
 
 import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.traits.TraitRegistry;
+import me.luisgamedev.betterhorses.utils.SupportedMountType;
 import org.bukkit.NamespacedKey;
-import org.bukkit.entity.Horse;
+import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -16,9 +17,10 @@ public class PassiveTraitListener implements Listener {
     @EventHandler
     public void onPlayerMove(PlayerMoveEvent event) {
         Player player = event.getPlayer();
-        if (!(player.getVehicle() instanceof Horse horse)) return;
+        if (!(player.getVehicle() instanceof AbstractHorse mount)) return;
+        if (!SupportedMountType.isSupported(mount)) return;
 
-        PersistentDataContainer data = horse.getPersistentDataContainer();
+        PersistentDataContainer data = mount.getPersistentDataContainer();
         NamespacedKey traitKey = new NamespacedKey(BetterHorses.getInstance(), "trait");
         if (!data.has(traitKey, PersistentDataType.STRING)) return;
 
@@ -26,13 +28,13 @@ public class PassiveTraitListener implements Listener {
 
         switch (trait) {
             case "frosthooves":
-                TraitRegistry.activateFrostHooves(player, horse);
+                TraitRegistry.activateFrostHooves(player, mount);
                 break;
             case "featherhooves":
-                TraitRegistry.activateFeatherHooves(player, horse);
+                TraitRegistry.activateFeatherHooves(player, mount);
                 break;
             case "fireheart":
-                TraitRegistry.activateFireheart(player, horse);
+                TraitRegistry.activateFireheart(player, mount);
                 break;
         }
     }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RevenantCurseListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RevenantCurseListener.java
@@ -1,8 +1,9 @@
 package me.luisgamedev.betterhorses.listeners;
 
 import me.luisgamedev.betterhorses.BetterHorses;
+import me.luisgamedev.betterhorses.utils.SupportedMountType;
 import org.bukkit.NamespacedKey;
-import org.bukkit.entity.Horse;
+import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -20,7 +21,7 @@ public class RevenantCurseListener implements Listener {
     public void onHorseOrRiderHit(EntityDamageByEntityEvent event) {
         if (!(event.getDamager() instanceof LivingEntity attacker)) return;
 
-        if (event.getEntity() instanceof Horse horse) {
+        if (event.getEntity() instanceof AbstractHorse horse) {
             if (hasActiveCurse(horse)) {
                 applyDebuff(attacker);
             }
@@ -28,13 +29,14 @@ public class RevenantCurseListener implements Listener {
         }
 
         if (event.getEntity() instanceof Player rider) {
-            if (rider.getVehicle() instanceof Horse horse && hasActiveCurse(horse)) {
+            if (rider.getVehicle() instanceof AbstractHorse horse && SupportedMountType.isSupported(horse) && hasActiveCurse(horse)) {
                 applyDebuff(attacker);
             }
         }
     }
 
-    private boolean hasActiveCurse(Horse horse) {
+    private boolean hasActiveCurse(AbstractHorse horse) {
+        if (!SupportedMountType.isSupported(horse)) return false;
         if (!horse.getPersistentDataContainer().has(CURSE_KEY, PersistentDataType.LONG)) return false;
         long until = horse.getPersistentDataContainer().get(CURSE_KEY, PersistentDataType.LONG);
         return System.currentTimeMillis() <= until;

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/TraitActivationListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/TraitActivationListener.java
@@ -3,10 +3,11 @@ package me.luisgamedev.betterhorses.listeners;
 import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.api.events.BetterHorseAbilityUseEvent;
 import me.luisgamedev.betterhorses.traits.TraitRegistry;
+import me.luisgamedev.betterhorses.utils.SupportedMountType;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
+import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.Horse;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -23,15 +24,16 @@ public class TraitActivationListener implements Listener {
         Player player = event.getPlayer();
         Entity vehicle = player.getVehicle();
 
-        if (!(vehicle instanceof Horse horse)) return;
+        if (!(vehicle instanceof AbstractHorse mount)) return;
+        if (!SupportedMountType.isSupported(mount)) return;
 
-        PersistentDataContainer data = horse.getPersistentDataContainer();
+        PersistentDataContainer data = mount.getPersistentDataContainer();
         if (!data.has(traitKey, PersistentDataType.STRING)) return;
 
         String trait = data.get(traitKey, PersistentDataType.STRING);
         if (trait == null) return;
 
-        BetterHorseAbilityUseEvent abilityEvent = new BetterHorseAbilityUseEvent(player, horse, trait.toLowerCase());
+        BetterHorseAbilityUseEvent abilityEvent = new BetterHorseAbilityUseEvent(player, mount, trait.toLowerCase());
         Bukkit.getPluginManager().callEvent(abilityEvent);
         if (abilityEvent.isCancelled()) {
             event.setCancelled(true);
@@ -41,19 +43,19 @@ public class TraitActivationListener implements Listener {
         String selectedTrait = abilityEvent.getTraitKey();
         switch (selectedTrait.toLowerCase()) {
             case "hellmare":
-                TraitRegistry.activateHellmare(player, horse);
+                TraitRegistry.activateHellmare(player, mount);
                 break;
             case "dashboost":
-                TraitRegistry.activateDashBoost(player, horse);
+                TraitRegistry.activateDashBoost(player, mount);
                 break;
             case "kickback":
-                TraitRegistry.activateKickback(player, horse);
+                TraitRegistry.activateKickback(player, mount);
                 break;
             case "ghosthorse":
-                TraitRegistry.activateGhostHorse(player, horse);
+                TraitRegistry.activateGhostHorse(player, mount);
                 break;
             case "revenantcurse":
-                TraitRegistry.activateRevenantCurse(player, horse);
+                TraitRegistry.activateRevenantCurse(player, mount);
                 break;
         }
 

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/tasks/TraitParticleTask.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/tasks/TraitParticleTask.java
@@ -5,9 +5,10 @@ import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Particle;
 import org.bukkit.World;
-import org.bukkit.entity.Horse;
+import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.persistence.PersistentDataType;
+import me.luisgamedev.betterhorses.utils.SupportedMountType;
 
 public class TraitParticleTask implements Runnable {
 
@@ -20,7 +21,8 @@ public class TraitParticleTask implements Runnable {
 
         for (World world : Bukkit.getWorlds()) {
             for (LivingEntity entity : world.getLivingEntities()) {
-                if (!(entity instanceof Horse horse)) continue;
+                if (!(entity instanceof AbstractHorse horse)) continue;
+                if (!SupportedMountType.isSupported(horse)) continue;
 
                 String trait = horse.getPersistentDataContainer().get(traitKey, PersistentDataType.STRING);
                 if (trait == null) continue;
@@ -60,7 +62,7 @@ public class TraitParticleTask implements Runnable {
         }
     }
 
-    private void spawn(Horse horse, Particle particle, int amount, double dx, double dy, double dz) {
+    private void spawn(AbstractHorse horse, Particle particle, int amount, double dx, double dy, double dz) {
         horse.getWorld().spawnParticle(particle, horse.getLocation().add(0, 1.2, 0), amount, dx, dy, dz, 0.01);
     }
 }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/traits/TraitRegistry.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/traits/TraitRegistry.java
@@ -33,7 +33,7 @@ public class TraitRegistry {
     static FileConfiguration config = BetterHorses.getInstance().getConfig();
     private static final Map<UUID, Double> dashBoostOriginalSpeeds = new HashMap<>();
 
-    public static void activateHellmare(Player player, Horse horse) {
+    public static void activateHellmare(Player player, AbstractHorse horse) {
         if (!config.getBoolean("traits.hellmare.enabled")) return;
 
         String key = "hellmare";
@@ -91,13 +91,13 @@ public class TraitRegistry {
         }.runTaskTimer(BetterHorses.getInstance(), 0, 5);
     }
 
-    public static void activateFireheart(Player player, Horse horse) {
+    public static void activateFireheart(Player player, AbstractHorse horse) {
         if (!config.getBoolean("traits.fireheart.enabled")) return;
         horse.addPotionEffect(new PotionEffect(PotionEffectType.FIRE_RESISTANCE, 10000, 0));
         player.addPotionEffect(new PotionEffect(PotionEffectType.FIRE_RESISTANCE, 20, 0));
     }
 
-    public static void activateHeavenHooves(Player player, Horse horse, Event event) {
+    public static void activateHeavenHooves(Player player, AbstractHorse horse, Event event) {
         if (!config.getBoolean("traits.heavenhooves.enabled")) return;
 
         horse.addPotionEffect(new PotionEffect(PotionEffectType.SLOW_FALLING, 10000, 0));
@@ -133,7 +133,7 @@ public class TraitRegistry {
 
 
 
-    public static void activateDashBoost(Player player, Horse horse) {
+    public static void activateDashBoost(Player player, AbstractHorse horse) {
         if (!config.getBoolean("traits.dashboost.enabled")) return;
 
         String key = "dashboost";
@@ -185,13 +185,13 @@ public class TraitRegistry {
         }
     }
 
-    public static void activateFeatherHooves(Player player, Horse horse) {
+    public static void activateFeatherHooves(Player player, AbstractHorse horse) {
         if (!config.getBoolean("traits.featherhooves.enabled")) return;
         player.addPotionEffect(new PotionEffect(PotionEffectType.SLOW_FALLING, 10, 0));
         horse.addPotionEffect(new PotionEffect(PotionEffectType.SLOW_FALLING, 10000, 0));
     }
 
-    public static void activateGhostHorse(Player player, Horse horse) {
+    public static void activateGhostHorse(Player player, AbstractHorse horse) {
         if (!config.getBoolean("traits.ghosthorse.enabled")) return;
 
         String key = "ghosthorse";
@@ -221,7 +221,7 @@ public class TraitRegistry {
         setCooldown(horse, key, config.getInt("traits.ghosthorse.cooldown", 30));
     }
 
-    public static void activateSkyburst(Player player, Horse horse) {
+    public static void activateSkyburst(Player player, AbstractHorse horse) {
         if (!config.getBoolean("traits.skyburst.enabled")) return;
 
         double radius = config.getDouble("traits.skyburst.radius", 3.0);
@@ -241,7 +241,7 @@ public class TraitRegistry {
         }
     }
 
-    public static void activateRevenantCurse(Player player, Horse horse) {
+    public static void activateRevenantCurse(Player player, AbstractHorse horse) {
         if (!config.getBoolean("traits.revenantcurse.enabled")) return;
 
         String key = "revenantcurse";
@@ -265,7 +265,7 @@ public class TraitRegistry {
         setCooldown(horse, key, config.getInt("traits.revenantcurse.cooldown", 30));
     }
 
-    public static void activateKickback(Player player, Horse horse) {
+    public static void activateKickback(Player player, AbstractHorse horse) {
         if (!config.getBoolean("traits.kickback.enabled")) return;
 
         String key = "kickback";
@@ -293,7 +293,7 @@ public class TraitRegistry {
         setCooldown(horse, key, config.getInt("traits.kickback.cooldown", 10));
     }
 
-    public static void activateFrostHooves(Player player, Horse horse) {
+    public static void activateFrostHooves(Player player, AbstractHorse horse) {
         if (!config.getBoolean("traits.frosthooves.enabled")) return;
 
         Location center = horse.getLocation().subtract(0, 1, 0);
@@ -320,7 +320,7 @@ public class TraitRegistry {
         }
     }
 
-    private static void showCooldownBar(Player player, Horse horse, String key) {
+    private static void showCooldownBar(Player player, AbstractHorse horse, String key) {
         int fullCooldown = config.getInt("traits." + key + ".cooldown", 30);
         long now = System.currentTimeMillis();
         long until = cooldowns.get(horse.getUniqueId()).getOrDefault(key, 0L);
@@ -332,7 +332,7 @@ public class TraitRegistry {
         }
     }
 
-    private static boolean isOnCooldown(Horse horse, String key) {
+    private static boolean isOnCooldown(AbstractHorse horse, String key) {
         UUID id = horse.getUniqueId();
         Map<String, Long> horseCooldowns = cooldowns.get(id);
         if (horseCooldowns == null) return false;
@@ -342,7 +342,7 @@ public class TraitRegistry {
         return now < until;
     }
 
-    private static void setCooldown(Horse horse, String key, int seconds) {
+    private static void setCooldown(AbstractHorse horse, String key, int seconds) {
         UUID id = horse.getUniqueId();
         cooldowns.putIfAbsent(id, new HashMap<>());
         cooldowns.get(id).put(key, System.currentTimeMillis() + seconds * 1000L);

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/ArmorHider.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/ArmorHider.java
@@ -6,9 +6,10 @@ import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.wrappers.EnumWrappers.ItemSlot;
 import com.comphenix.protocol.wrappers.Pair;
 import me.luisgamedev.betterhorses.BetterHorses;
-import org.bukkit.entity.Horse;
+import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.HorseInventory;
+import org.bukkit.inventory.AbstractHorseInventory;
+import org.bukkit.inventory.ArmoredHorseInventory;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
@@ -16,7 +17,7 @@ import java.util.List;
 
 public class ArmorHider {
 
-    public static void hide(Player player, Horse horse) {
+    public static void hide(Player player, AbstractHorse horse) {
         if (!BetterHorses.getInstance().isProtocolLibAvailable()) return;
 
         try {
@@ -34,7 +35,7 @@ public class ArmorHider {
             playerPacket.getSlotStackPairLists().write(0, hiddenPlayer);
 
             // hide horse armor
-            HorseInventory inv = horse.getInventory();
+            AbstractHorseInventory inv = horse.getInventory();
             List<Pair<ItemSlot, ItemStack>> hiddenHorse = new ArrayList<>();
             hiddenHorse.add(new Pair<>(ItemSlot.CHEST, null));
 
@@ -52,7 +53,7 @@ public class ArmorHider {
         }
     }
 
-    public static void show(Player player, Horse horse) {
+    public static void show(Player player, AbstractHorse horse) {
         if (!BetterHorses.getInstance().isProtocolLibAvailable()) {
             return;
         }
@@ -72,9 +73,10 @@ public class ArmorHider {
             playerPacket.getSlotStackPairLists().write(0, visiblePlayer);
 
             // show horse armor
-            HorseInventory inv = horse.getInventory();
+            AbstractHorseInventory inv = horse.getInventory();
             List<Pair<ItemSlot, ItemStack>> visibleHorse = new ArrayList<>();
-            visibleHorse.add(new Pair<>(ItemSlot.CHEST, inv.getArmor()));
+            ItemStack armor = inv instanceof ArmoredHorseInventory armored ? armored.getArmor() : null;
+            visibleHorse.add(new Pair<>(ItemSlot.CHEST, armor));
 
             PacketContainer horsePacket = new PacketContainer(PacketType.Play.Server.ENTITY_EQUIPMENT);
             horsePacket.getIntegers().write(0, horse.getEntityId());


### PR DESCRIPTION
## Summary
- allow trait activation, passive effects, and particle indicators to run for every supported mount type
- update ability event API to expose generic mounts while keeping the horse-specific constructor for compatibility
- make armor hiding utilities and trait handlers operate on AbstractHorse implementations

## Testing
- `./gradlew test`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695052c59e90832bb7f1d43cf8fc9960)