### PR TITLE
Support new attribute names and armor persistence

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorse.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorse.java
@@ -1,5 +1,6 @@
 package me.luisgamedev.betterhorses.api;
 
+import me.luisgamedev.betterhorses.utils.AttributeResolver;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.AbstractHorse;
@@ -25,21 +26,21 @@ public final class BetterHorse {
     }
 
     public double getMaxHealth() {
-        AttributeInstance attr = handle.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+        AttributeInstance attr = handle.getAttribute(AttributeResolver.generic("MAX_HEALTH"));
         return attr != null ? attr.getBaseValue() : 0.0;
     }
 
     public void setMaxHealth(double value) {
-        setAttribute(Attribute.GENERIC_MAX_HEALTH, BetterHorseKeys.HEALTH, value);
+        setAttribute(AttributeResolver.generic("MAX_HEALTH"), BetterHorseKeys.HEALTH, value);
     }
 
     public double getSpeed() {
-        AttributeInstance attr = handle.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+        AttributeInstance attr = handle.getAttribute(AttributeResolver.generic("MOVEMENT_SPEED"));
         return attr != null ? attr.getBaseValue() : 0.0;
     }
 
     public void setSpeed(double value) {
-        setAttribute(Attribute.GENERIC_MOVEMENT_SPEED, BetterHorseKeys.SPEED, value);
+        setAttribute(AttributeResolver.generic("MOVEMENT_SPEED"), BetterHorseKeys.SPEED, value);
     }
 
     public double getJump() {

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/DespawnCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/DespawnCommand.java
@@ -4,6 +4,8 @@ import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.api.BetterHorsesAPI;
 import me.luisgamedev.betterhorses.language.LanguageManager;
 import me.luisgamedev.betterhorses.traits.TraitRegistry;
+import me.luisgamedev.betterhorses.utils.AttributeResolver;
+import me.luisgamedev.betterhorses.utils.HorseArmorUtils;
 import me.luisgamedev.betterhorses.utils.MountConfig;
 import me.luisgamedev.betterhorses.utils.SupportedMountType;
 import org.bukkit.Material;
@@ -15,7 +17,6 @@ import org.bukkit.entity.AnimalTamer;
 import org.bukkit.entity.Horse;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.AbstractHorseInventory;
-import org.bukkit.inventory.ArmoredHorseInventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
@@ -92,9 +93,9 @@ public class DespawnCommand {
 
         TraitRegistry.revertDashBoostIfActive(horse);
 
-        double maxHealth = horse.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue();
+        double maxHealth = horse.getAttribute(AttributeResolver.generic("MAX_HEALTH")).getBaseValue();
         double currentHealth = horse.getHealth();
-        double speed = horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED).getBaseValue();
+        double speed = horse.getAttribute(AttributeResolver.generic("MOVEMENT_SPEED")).getBaseValue();
         AttributeInstance jumpAttr = horse.getAttribute(Attribute.valueOf("HORSE_JUMP_STRENGTH"));
         double jump = jumpAttr != null ? jumpAttr.getBaseValue() : 0.0;
 
@@ -102,7 +103,7 @@ public class DespawnCommand {
         Horse.Color color = horse instanceof Horse ? ((Horse) horse).getColor() : Horse.Color.WHITE;
         AbstractHorseInventory inv = horse.getInventory();
         ItemStack saddle = inv.getSaddle();
-        ItemStack armor = inv instanceof ArmoredHorseInventory armoredInv ? armoredInv.getArmor() : null;
+        ItemStack armor = HorseArmorUtils.getArmor(inv);
 
         String itemMaterialName = BetterHorses.getInstance().getConfig().getString("settings.horse-item", "SADDLE");
         Material material = Material.getMaterial(itemMaterialName.toUpperCase());

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/RespawnCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/RespawnCommand.java
@@ -4,6 +4,8 @@ import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.api.BetterHorsesAPI;
 import me.luisgamedev.betterhorses.api.events.BetterHorseSpawnEvent;
 import me.luisgamedev.betterhorses.language.LanguageManager;
+import me.luisgamedev.betterhorses.utils.AttributeResolver;
+import me.luisgamedev.betterhorses.utils.HorseArmorUtils;
 import me.luisgamedev.betterhorses.utils.MountConfig;
 import me.luisgamedev.betterhorses.utils.SupportedMountType;
 import org.bukkit.Material;
@@ -13,7 +15,6 @@ import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.Horse;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ArmoredHorseInventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
@@ -107,8 +108,8 @@ public class RespawnCommand {
                 growthStage
         );
 
-        setAttribute(horse, Attribute.GENERIC_MAX_HEALTH, health);
-        setAttribute(horse, Attribute.GENERIC_MOVEMENT_SPEED, speed);
+        setAttribute(horse, AttributeResolver.generic("MAX_HEALTH"), health);
+        setAttribute(horse, AttributeResolver.generic("MOVEMENT_SPEED"), speed);
         setAttribute(horse, Attribute.valueOf("HORSE_JUMP_STRENGTH"), jump);
         horse.setHealth(currentHealth != null ? currentHealth : health);
         horse.setTamed(true);
@@ -148,9 +149,7 @@ public class RespawnCommand {
             horse.getInventory().setSaddle(new ItemStack(Material.valueOf(saddleStr)));
         }
         if (armorStr != null) {
-            if (horse.getInventory() instanceof ArmoredHorseInventory armoredInventory) {
-                armoredInventory.setArmor(new ItemStack(Material.valueOf(armorStr)));
-            }
+            HorseArmorUtils.setArmor(horse.getInventory(), new ItemStack(Material.valueOf(armorStr)));
         }
 
         item.setAmount(item.getAmount() - 1);

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseBreedListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseBreedListener.java
@@ -6,6 +6,7 @@ import me.luisgamedev.betterhorses.api.events.BetterHorseBreedEvent;
 import me.luisgamedev.betterhorses.utils.MountConfig;
 import me.luisgamedev.betterhorses.utils.SupportedMountType;
 import org.bukkit.Bukkit;
+import me.luisgamedev.betterhorses.utils.AttributeResolver;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.configuration.ConfigurationSection;
@@ -173,12 +174,12 @@ public class HorseBreedListener implements Listener {
     }
 
     private double getHealth(AbstractHorse horse) {
-        AttributeInstance attribute = horse.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+        AttributeInstance attribute = horse.getAttribute(AttributeResolver.generic("MAX_HEALTH"));
         return attribute != null ? attribute.getBaseValue() : 0.0;
     }
 
     private double getSpeed(AbstractHorse horse) {
-        AttributeInstance attribute = horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+        AttributeInstance attribute = horse.getAttribute(AttributeResolver.generic("MOVEMENT_SPEED"));
         return attribute != null ? attribute.getBaseValue() : 0.0;
     }
 
@@ -188,7 +189,7 @@ public class HorseBreedListener implements Listener {
     }
 
     private void setHealth(AbstractHorse horse, double value) {
-        AttributeInstance attr = horse.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+        AttributeInstance attr = horse.getAttribute(AttributeResolver.generic("MAX_HEALTH"));
         if (attr != null) {
             attr.setBaseValue(value);
         }
@@ -196,7 +197,7 @@ public class HorseBreedListener implements Listener {
     }
 
     private void setSpeed(AbstractHorse horse, double value) {
-        AttributeInstance attribute = horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+        AttributeInstance attribute = horse.getAttribute(AttributeResolver.generic("MOVEMENT_SPEED"));
         if (attribute != null) {
             attribute.setBaseValue(value);
         }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseStepHeightListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseStepHeightListener.java
@@ -2,6 +2,7 @@ package me.luisgamedev.betterhorses.listeners;
 
 import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.utils.SupportedMountType;
+import me.luisgamedev.betterhorses.utils.AttributeResolver;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -37,7 +38,7 @@ public class HorseStepHeightListener implements Listener {
 
     private void setStepHeightSafe(AbstractHorse horse, double stepHeight) {
         try {
-            Attribute attr = Attribute.valueOf("GENERIC_STEP_HEIGHT");
+            Attribute attr = AttributeResolver.generic("STEP_HEIGHT");
             AttributeInstance instance = horse.getAttribute(attr);
             if (instance != null) {
                 instance.setBaseValue(stepHeight);

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RightClickListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RightClickListener.java
@@ -4,6 +4,8 @@ import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.api.BetterHorsesAPI;
 import me.luisgamedev.betterhorses.api.events.BetterHorseSpawnEvent;
 import me.luisgamedev.betterhorses.language.LanguageManager;
+import me.luisgamedev.betterhorses.utils.AttributeResolver;
+import me.luisgamedev.betterhorses.utils.HorseArmorUtils;
 import me.luisgamedev.betterhorses.utils.MountConfig;
 import me.luisgamedev.betterhorses.utils.SupportedMountType;
 import org.bukkit.Material;
@@ -19,7 +21,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.inventory.ArmoredHorseInventory;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -117,8 +118,8 @@ public class RightClickListener implements Listener {
             }
         }
 
-        setAttribute(horse, Attribute.GENERIC_MAX_HEALTH, health);
-        setAttribute(horse, Attribute.GENERIC_MOVEMENT_SPEED, speed);
+        setAttribute(horse, AttributeResolver.generic("MAX_HEALTH"), health);
+        setAttribute(horse, AttributeResolver.generic("MOVEMENT_SPEED"), speed);
         setAttribute(horse, Attribute.valueOf("HORSE_JUMP_STRENGTH"), jump);
         horse.setHealth(currentHealth != null ? currentHealth : health);
         horse.setTamed(true);
@@ -158,9 +159,7 @@ public class RightClickListener implements Listener {
             horse.getInventory().setSaddle(new ItemStack(Material.valueOf(saddleStr)));
         }
         if (armorStr != null) {
-            if (horse.getInventory() instanceof ArmoredHorseInventory armoredInventory) {
-                armoredInventory.setArmor(new ItemStack(Material.valueOf(armorStr)));
-            }
+            HorseArmorUtils.setArmor(horse.getInventory(), new ItemStack(Material.valueOf(armorStr)));
         }
 
         item.setAmount(item.getAmount() - 1);

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/traits/TraitRegistry.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/traits/TraitRegistry.java
@@ -5,6 +5,7 @@ import me.luisgamedev.betterhorses.language.LanguageManager;
 import me.luisgamedev.betterhorses.utils.ArmorHider;
 import me.luisgamedev.betterhorses.utils.CooldownDisplay;
 import org.bukkit.*;
+import me.luisgamedev.betterhorses.utils.AttributeResolver;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.block.Block;
@@ -143,7 +144,7 @@ public class TraitRegistry {
         }
 
         int duration = config.getInt("traits.dashboost.duration", 5);
-        AttributeInstance speedAttr = horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+        AttributeInstance speedAttr = horse.getAttribute(AttributeResolver.generic("MOVEMENT_SPEED"));
         if (speedAttr == null) return;
 
         double originalSpeed = speedAttr.getBaseValue();
@@ -162,7 +163,7 @@ public class TraitRegistry {
                 double revertSpeed = storedOriginal != null ? storedOriginal : originalSpeed;
 
                 if (horse.isValid()) {
-                    AttributeInstance speedAttr = horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+                    AttributeInstance speedAttr = horse.getAttribute(AttributeResolver.generic("MOVEMENT_SPEED"));
                     if (speedAttr != null) {
                         speedAttr.setBaseValue(revertSpeed);
                     }
@@ -179,7 +180,7 @@ public class TraitRegistry {
 
         if (!horse.isValid()) return;
 
-        AttributeInstance speedAttr = horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+        AttributeInstance speedAttr = horse.getAttribute(AttributeResolver.generic("MOVEMENT_SPEED"));
         if (speedAttr != null) {
             speedAttr.setBaseValue(storedOriginal);
         }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/AttributeResolver.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/AttributeResolver.java
@@ -1,0 +1,63 @@
+package me.luisgamedev.betterhorses.utils;
+
+import org.bukkit.Bukkit;
+import org.bukkit.attribute.Attribute;
+
+/**
+ * Resolves attribute names across Minecraft versions where the Bukkit
+ * attribute enum changed from the "GENERIC_" prefix to prefix-less names.
+ */
+public final class AttributeResolver {
+
+    private static final boolean USE_GENERIC_PREFIX = !isAtLeast(1, 21, 11);
+
+    private AttributeResolver() {}
+
+    /**
+     * Resolves an attribute that used to have the {@code GENERIC_} prefix.
+     *
+     * @param baseName attribute name without the {@code GENERIC_} prefix
+     * @return the matching {@link Attribute} for the running server version
+     */
+    public static Attribute generic(String baseName) {
+        String normalized = baseName.startsWith("GENERIC_")
+                ? baseName.substring("GENERIC_".length())
+                : baseName;
+
+        if (USE_GENERIC_PREFIX) {
+            return resolveWithFallback("GENERIC_" + normalized, normalized);
+        }
+
+        return resolveWithFallback(normalized, "GENERIC_" + normalized);
+    }
+
+    private static Attribute resolveWithFallback(String primary, String fallback) {
+        try {
+            return Attribute.valueOf(primary);
+        } catch (IllegalArgumentException ignored) {
+            return Attribute.valueOf(fallback);
+        }
+    }
+
+    private static boolean isAtLeast(int major, int minor, int patch) {
+        String version = Bukkit.getMinecraftVersion();
+        String[] parts = version.split("[-+]")[0].split("\\.");
+
+        int serverMajor = parsePart(parts, 0);
+        int serverMinor = parsePart(parts, 1);
+        int serverPatch = parsePart(parts, 2);
+
+        if (serverMajor != major) return serverMajor > major;
+        if (serverMinor != minor) return serverMinor > minor;
+        return serverPatch >= patch;
+    }
+
+    private static int parsePart(String[] parts, int index) {
+        if (index >= parts.length) return 0;
+        try {
+            return Integer.parseInt(parts[index].replaceAll("[^0-9]", ""));
+        } catch (NumberFormatException ignored) {
+            return 0;
+        }
+    }
+}

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/HorseArmorUtils.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/HorseArmorUtils.java
@@ -1,0 +1,59 @@
+package me.luisgamedev.betterhorses.utils;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.AbstractHorseInventory;
+import org.bukkit.inventory.ArmoredHorseInventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.lang.reflect.Method;
+
+public final class HorseArmorUtils {
+
+    private HorseArmorUtils() {
+    }
+
+    public static ItemStack getArmor(AbstractHorseInventory inventory) {
+        if (inventory == null) return null;
+
+        ItemStack armor = null;
+        if (inventory instanceof ArmoredHorseInventory armoredInventory) {
+            armor = armoredInventory.getArmor();
+        } else {
+            armor = invokeGetter(inventory);
+        }
+
+        if (armor == null || armor.getType() == Material.AIR) return null;
+        return armor;
+    }
+
+    public static void setArmor(AbstractHorseInventory inventory, ItemStack armor) {
+        if (inventory == null || armor == null || armor.getType() == Material.AIR) return;
+
+        if (inventory instanceof ArmoredHorseInventory armoredInventory) {
+            armoredInventory.setArmor(armor);
+            return;
+        }
+
+        invokeSetter(inventory, armor);
+    }
+
+    private static ItemStack invokeGetter(AbstractHorseInventory inventory) {
+        try {
+            Method getter = inventory.getClass().getMethod("getArmor");
+            Object result = getter.invoke(inventory);
+            if (result instanceof ItemStack) {
+                return (ItemStack) result;
+            }
+        } catch (ReflectiveOperationException ignored) {
+        }
+        return null;
+    }
+
+    private static void invokeSetter(AbstractHorseInventory inventory, ItemStack armor) {
+        try {
+            Method setter = inventory.getClass().getMethod("setArmor", ItemStack.class);
+            setter.invoke(inventory, armor);
+        } catch (ReflectiveOperationException ignored) {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add attribute resolution helper to choose GENERIC_ prefix based on server version and apply to horse stat reads/writes
- use shared armor utilities so skeleton and zombie horses with armor slots have their armor saved and restored

## Testing
- ./gradlew test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ad2da61a8832ba5740dde1cfc2832)