### PR TITLE
Expand debug logging and add mounted-horse details to `/horse info`

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
@@ -30,6 +30,7 @@ public class BetterHorses extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        debugLog("PLUGIN", "ENABLE_START", true, "Starting BetterHorses plugin bootstrap.");
         if (getServer().getPluginManager().getPlugin("ProtocolLib") != null) {
             protocolLibAvailable = true;
             protocolManager = ProtocolLibrary.getProtocolManager();
@@ -63,6 +64,7 @@ public class BetterHorses extends JavaPlugin {
                 20L, // delay 1s
                 20L  // repeat every 1s
         );
+        debugLog("PLUGIN", "ENABLE_COMPLETE", true, "BetterHorses plugin enabled successfully.");
     }
 
     public static BetterHorses getInstance() {
@@ -77,6 +79,7 @@ public class BetterHorses extends JavaPlugin {
         reloadConfig();
         languageManager.reload();
         applyHorseCommandAliases();
+        debugLog("PLUGIN", "RELOAD", true, "Configuration and language files were reloaded.");
     }
 
     public boolean isProtocolLibAvailable() {
@@ -104,6 +107,7 @@ public class BetterHorses extends JavaPlugin {
     private void applyHorseCommandAliases() {
         PluginCommand horseCommand = getCommand("horse");
         if (horseCommand == null) {
+            debugLog("PLUGIN", "COMMAND_ALIAS", false, "Horse command is unavailable while applying aliases.");
             return;
         }
         List<String> aliases = getConfig().getStringList("command-aliases");
@@ -117,10 +121,13 @@ public class BetterHorses extends JavaPlugin {
                 commandMap.register(getDescription().getName(), horseCommand);
             } else {
                 getLogger().warning("Unable to refresh horse command aliases because the command map is unavailable.");
+                debugLog("PLUGIN", "COMMAND_ALIAS", false, "Command map was unavailable for alias refresh.");
             }
         } catch (ReflectiveOperationException exception) {
             getLogger().log(Level.WARNING, "Failed to refresh horse command aliases.", exception);
+            debugLog("PLUGIN", "COMMAND_ALIAS", false, "Failed to refresh aliases due to reflection error: " + exception.getMessage());
         }
+        debugLog("PLUGIN", "COMMAND_ALIAS", true, "Applied /horse aliases: " + aliases);
     }
 
     private void registerListeners() {
@@ -132,43 +139,53 @@ public class BetterHorses extends JavaPlugin {
         pluginManager.registerEvents(new HorseFeedListener(), this);
         pluginManager.registerEvents(new HorseItemBlockerListener(), this);
         pluginManager.registerEvents(new HorseMountListener(), this);
+        debugLog("LISTENER", "REGISTER_BASE", true, "Registered core horse listeners.");
 
         if (config.getBoolean("settings.allow-rightclick-spawn", true)) {
             pluginManager.registerEvents(new RightClickListener(), this);
+            debugLog("LISTENER", "REGISTER", true, "Registered RightClickListener.");
         }
 
         if (config.getBoolean("settings.rider-invulnerable", false)) {
             pluginManager.registerEvents(new RiderInvulnerableListener(), this);
+            debugLog("LISTENER", "REGISTER", true, "Registered RiderInvulnerableListener.");
         }
 
         if (config.getBoolean("settings.fix-step-height", false)) {
             pluginManager.registerEvents(new HorseStepHeightListener(), this);
+            debugLog("LISTENER", "REGISTER", true, "Registered HorseStepHeightListener.");
         }
 
         if (config.getBoolean("settings.mounted-damage-boost.enabled", false)) {
             pluginManager.registerEvents(new MountedDamageBoostListener(), this);
+            debugLog("LISTENER", "REGISTER", true, "Registered MountedDamageBoostListener.");
         }
 
         boolean traitsEnabled = config.getBoolean("traits.enabled", true);
         if (!traitsEnabled) {
+            debugLog("LISTENER", "REGISTER_TRAITS", false, "Trait listeners were skipped because traits are disabled.");
             return;
         }
 
         if (isAnyTraitEnabled("hellmare", "dashboost", "kickback", "ghosthorse", "revenantcurse")) {
             pluginManager.registerEvents(new TraitActivationListener(), this);
+            debugLog("LISTENER", "REGISTER", true, "Registered TraitActivationListener.");
         }
 
         if (isAnyTraitEnabled("frosthooves", "featherhooves", "fireheart")) {
             pluginManager.registerEvents(new PassiveTraitListener(), this);
+            debugLog("LISTENER", "REGISTER", true, "Registered PassiveTraitListener.");
         }
 
         if (config.getBoolean("traits.revenantcurse.enabled", false)) {
             pluginManager.registerEvents(new RevenantCurseListener(), this);
+            debugLog("LISTENER", "REGISTER", true, "Registered RevenantCurseListener.");
         }
 
         if (config.getBoolean("traits.skyburst.enabled", false)
                 || config.getBoolean("traits.heavenhooves.enabled", false)) {
             pluginManager.registerEvents(new HorseJumpListener(), this);
+            debugLog("LISTENER", "REGISTER", true, "Registered HorseJumpListener.");
         }
     }
 

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
@@ -36,6 +36,7 @@ public class BetterHorsesAPI {
 
         BetterHorses plugin = BetterHorses.getInstance();
         LanguageManager lang = plugin.getLang();
+        plugin.debugLog("API_CREATE_ITEM", "START", true, "Creating horse item health=" + health + ", speed=" + speed + ", jump=" + jump + ".");
         SupportedMountType targetMountType = mountType == null ? SupportedMountType.HORSE : mountType;
 
         String genderSymbol = gender.equals("male") ? lang.getRaw("messages.gender-male") : gender.equals("female") ? lang.getRaw("messages.gender-female") : "?";
@@ -43,6 +44,7 @@ public class BetterHorsesAPI {
         String materialName = plugin.getConfig().getString("settings.horse-item", "SADDLE");
         Material material = Material.getMaterial(materialName.toUpperCase());
         if (material == null || !material.isItem()) material = Material.SADDLE;
+        plugin.debugLog("API_CREATE_ITEM", "MATERIAL", true, "Using horse item material " + material + ".");
 
         ItemStack item = new ItemStack(material);
         ItemMeta meta = item.getItemMeta();
@@ -104,12 +106,14 @@ public class BetterHorsesAPI {
         item.setItemMeta(meta);
 
         if(targetInventory != null) {
+            plugin.debugLog("API_CREATE_ITEM", "INVENTORY", true, "Adding horse item to target inventory.");
             HashMap<Integer, ItemStack> leftovers = targetInventory.addItem(item);
             if (!leftovers.isEmpty() && dropIfFull) {
                 owner.getWorld().dropItem(owner.getLocation(), item);
             }
         }
 
+        plugin.debugLog("API_CREATE_ITEM", "COMPLETE", true, "Horse item created with mount type " + targetMountType.getEntityType() + ".");
         return item;
     }
 
@@ -142,13 +146,17 @@ public class BetterHorsesAPI {
     }
 
     public static void callSpawnEvent(AbstractHorse horse, ItemStack sourceItem, BetterHorseSpawnEvent.SpawnCause cause) {
+        BetterHorses.getInstance().debugLog("API_EVENT", "SPAWN", true, "Calling BetterHorseSpawnEvent for " + horse.getUniqueId() + " cause=" + cause + ".");
         Bukkit.getPluginManager().callEvent(new BetterHorseSpawnEvent(horse, sourceItem, cause));
     }
 
     public static boolean callDespawnEvent(AbstractHorse horse, ItemStack resultItem) {
+        BetterHorses.getInstance().debugLog("API_EVENT", "DESPAWN", true, "Calling BetterHorseDespawnEvent for " + horse.getUniqueId() + ".");
         BetterHorseDespawnEvent event = new BetterHorseDespawnEvent(horse, resultItem);
         Bukkit.getPluginManager().callEvent(event);
-        return event.isCancelled();
+        boolean cancelled = event.isCancelled();
+        BetterHorses.getInstance().debugLog("API_EVENT", "DESPAWN_RESULT", !cancelled, "Despawn event cancelled=" + cancelled + ".");
+        return cancelled;
     }
 
     private static String formatTraitName(String raw) {

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/CustomHorseCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/CustomHorseCommand.java
@@ -20,20 +20,25 @@ public class CustomHorseCommand implements CommandExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        LanguageManager lang = BetterHorses.getInstance().getLang();
+        BetterHorses plugin = BetterHorses.getInstance();
+        LanguageManager lang = plugin.getLang();
+        plugin.debugLog("HORSE_CREATE", "RECEIVED", true, "Sender=" + sender.getName() + ", args=" + args.length + ".");
 
         if (!(sender instanceof Player player)) {
             sender.sendMessage(lang.get("messages.only-players"));
+            plugin.debugLog("HORSE_CREATE", "PLAYER_REQUIRED", false, "Non-player sender attempted /horsecreate.");
             return true;
         }
 
         if (!player.hasPermission("betterhorses.create")) {
             player.sendMessage(lang.getFormatted("messages.insufficient-permission", "%command%", "/horsecreate"));
+            plugin.debugLog("HORSE_CREATE", "PERMISSION", false, "Player " + player.getName() + " lacks betterhorses.create.");
             return true;
         }
 
         if (args.length < 3) {
             player.sendMessage(lang.get("messages.horsecreate-usage"));
+            plugin.debugLog("HORSE_CREATE", "USAGE", false, "Player " + player.getName() + " provided too few arguments.");
             return true;
         }
 
@@ -52,11 +57,13 @@ public class CustomHorseCommand implements CommandExecutor {
             SupportedMountType mountType = mountTypeArg == null ? SupportedMountType.HORSE : SupportedMountType.fromUserInput(mountTypeArg).orElse(null);
             if (mountType == null) {
                 player.sendMessage(lang.getFormatted("messages.invalid-mount-type", "%types%", getEnabledMountTypes(config)));
+                plugin.debugLog("HORSE_CREATE", "MOUNT_TYPE", false, "Invalid mount type input: " + mountTypeArg);
                 return true;
             }
 
             if (!mountType.isEnabled(config)) {
                 player.sendMessage(lang.get("messages.mount-type-disabled"));
+                plugin.debugLog("HORSE_CREATE", "MOUNT_TYPE", false, "Disabled mount type requested: " + mountType.getEntityType());
                 return true;
             }
 
@@ -65,12 +72,14 @@ public class CustomHorseCommand implements CommandExecutor {
             if (trait != null && !trait.equalsIgnoreCase("none")) {
                 if (!config.getBoolean("traits.enabled", false)) {
                     player.sendMessage(lang.get("messages.traits-disabled"));
+                    plugin.debugLog("HORSE_CREATE", "TRAIT", false, "Trait requested while traits are disabled.");
                     return true;
                 }
 
                 ConfigurationSection traitSection = config.getConfigurationSection("traits." + trait);
                 if (traitSection == null || !traitSection.getBoolean("enabled", false)) {
                     player.sendMessage(lang.get("messages.traits-error"));
+                    plugin.debugLog("HORSE_CREATE", "TRAIT", false, "Invalid or disabled trait requested: " + trait);
                     return true;
                 }
 
@@ -79,10 +88,12 @@ public class CustomHorseCommand implements CommandExecutor {
 
             Inventory target = player.getInventory();
             BetterHorsesAPI.createHorseItem(health, speed, jump, gender, name, player, target, true, validatedTrait, growthStage, mountType);
+            plugin.debugLog("HORSE_CREATE", "COMPLETE", true, "Created item for " + player.getName() + " with mount=" + mountType.getEntityType() + ", trait=" + validatedTrait + ".");
             return true;
 
         } catch (NumberFormatException e) {
             player.sendMessage(lang.get("messages.invalid-number-format"));
+            plugin.debugLog("HORSE_CREATE", "PARSE", false, "Invalid numeric argument from " + player.getName() + ": " + e.getMessage());
             return true;
         }
     }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/DespawnCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/DespawnCommand.java
@@ -29,10 +29,13 @@ import java.util.List;
 public class DespawnCommand {
 
     public static boolean despawnHorseToItem(Player player) {
-        LanguageManager lang = BetterHorses.getInstance().getLang();
+        BetterHorses plugin = BetterHorses.getInstance();
+        LanguageManager lang = plugin.getLang();
+        plugin.debugLog("HORSE_DESPAWN", "START", true, "Player " + player.getName() + " requested despawn.");
 
         if (!(player.getVehicle() instanceof AbstractHorse horse)) {
             player.sendMessage(lang.get("messages.invalid-vehicle"));
+            plugin.debugLog("HORSE_DESPAWN", "VALIDATION", false, "Player " + player.getName() + " is not riding a supported mount.");
             return true;
         }
 
@@ -42,6 +45,7 @@ public class DespawnCommand {
 
         if (mountType == null) {
             player.sendMessage(lang.get("messages.invalid-vehicle"));
+            plugin.debugLog("HORSE_DESPAWN", "MOUNT_TYPE", false, "Mount type disabled or unsupported for player " + player.getName() + ".");
             return true;
         }
 
@@ -66,6 +70,7 @@ public class DespawnCommand {
 
         if (ownershipRequired && !isOwner) {
             player.sendMessage(lang.getFormatted("messages.not-horse-owner", "%mount%", mountName));
+            plugin.debugLog("HORSE_DESPAWN", "OWNERSHIP", false, "Player " + player.getName() + " is not owner of " + horse.getUniqueId() + ".");
             return true;
         }
 
@@ -162,6 +167,7 @@ public class DespawnCommand {
         boolean wasLeashed = horse.isLeashed();
 
         if (BetterHorsesAPI.callDespawnEvent(horse, item)) {
+            plugin.debugLog("HORSE_DESPAWN", "EVENT", false, "Despawn was cancelled for horse " + horse.getUniqueId() + ".");
             return true;
         }
 
@@ -169,6 +175,7 @@ public class DespawnCommand {
 
         if (horse.isValid()) {
             player.sendMessage(lang.get("messages.cant-despawn"));
+            plugin.debugLog("HORSE_DESPAWN", "REMOVE", false, "Horse remained valid after remove call: " + horse.getUniqueId());
             return true;
         }
 
@@ -183,6 +190,7 @@ public class DespawnCommand {
         }
 
         player.sendMessage(lang.getFormatted("messages.horse-despawned", "%mount%", mountName));
+        plugin.debugLog("HORSE_DESPAWN", "COMPLETE", true, "Player " + player.getName() + " despawned " + mountName + ".");
         return true;
     }
 

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseInfoCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseInfoCommand.java
@@ -1,8 +1,13 @@
 package me.luisgamedev.betterhorses.commands;
 
 import me.luisgamedev.betterhorses.BetterHorses;
+import me.luisgamedev.betterhorses.api.BetterHorseKeys;
 import org.bukkit.ChatColor;
 import org.bukkit.NamespacedKey;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.entity.AbstractHorse;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
@@ -10,7 +15,6 @@ import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
-
 
 public final class HorseInfoCommand {
 
@@ -20,64 +24,104 @@ public final class HorseInfoCommand {
     public static boolean handle(Player player) {
         BetterHorses plugin = BetterHorses.getInstance();
         ItemStack item = player.getInventory().getItemInMainHand();
+        boolean inspectedItem = false;
 
-        if (item == null || item.getType().isAir() || !item.hasItemMeta()) {
-            player.sendMessage(ChatColor.RED + "Hold a horse item in your main hand first.");
+        if (item != null && !item.getType().isAir() && item.hasItemMeta()) {
+            inspectedItem = true;
+            ItemMeta meta = item.getItemMeta();
+            PersistentDataContainer container = meta.getPersistentDataContainer();
+
+            player.sendMessage(ChatColor.GOLD + "------ BetterHorses Item Debug ------");
+            player.sendMessage(ChatColor.YELLOW + "Type: " + ChatColor.WHITE + item.getType());
+            player.sendMessage(ChatColor.YELLOW + "Amount: " + ChatColor.WHITE + item.getAmount());
+            player.sendMessage(ChatColor.YELLOW + "Display Name: " + ChatColor.WHITE
+                    + (meta.hasDisplayName() ? meta.getDisplayName() : "<none>"));
+            player.sendMessage(ChatColor.YELLOW + "Unbreakable: " + ChatColor.WHITE + meta.isUnbreakable());
+
+            if (meta instanceof Damageable damageable) {
+                player.sendMessage(ChatColor.YELLOW + "Damage: " + ChatColor.WHITE + damageable.getDamage());
+            }
+
+            player.sendMessage(ChatColor.YELLOW + "CustomModelData: " + ChatColor.WHITE
+                    + (meta.hasCustomModelData() ? meta.getCustomModelData() : "<none>"));
+
+            if (meta.hasLore()) {
+                player.sendMessage(ChatColor.YELLOW + "Lore:");
+                for (String line : meta.getLore()) {
+                    player.sendMessage(ChatColor.GRAY + "  - " + line);
+                }
+            } else {
+                player.sendMessage(ChatColor.YELLOW + "Lore: " + ChatColor.WHITE + "<none>");
+            }
+
+            if (!meta.getItemFlags().isEmpty()) {
+                player.sendMessage(ChatColor.YELLOW + "ItemFlags:");
+                for (ItemFlag itemFlag : meta.getItemFlags()) {
+                    player.sendMessage(ChatColor.GRAY + "  - " + itemFlag.name());
+                }
+            } else {
+                player.sendMessage(ChatColor.YELLOW + "ItemFlags: " + ChatColor.WHITE + "<none>");
+            }
+
+            if (container.getKeys().isEmpty()) {
+                player.sendMessage(ChatColor.YELLOW + "PersistentData: " + ChatColor.WHITE + "<none>");
+                plugin.debugLog("HORSE_INFO", "PDC_SCAN", true,
+                        "Player " + player.getName() + " inspected item without custom PDC keys.");
+            } else {
+                player.sendMessage(ChatColor.YELLOW + "PersistentData:");
+                for (NamespacedKey key : container.getKeys()) {
+                    String renderedValue = resolveValue(container, key);
+                    player.sendMessage(ChatColor.GRAY + "  - " + key + ChatColor.WHITE + " = " + renderedValue);
+                }
+            }
+        }
+
+        boolean inspectedMount = inspectMountedHorse(player, plugin);
+
+        if (!inspectedItem && !inspectedMount) {
+            player.sendMessage(ChatColor.RED + "Hold a horse item in your main hand or ride a horse first.");
             plugin.debugLog("HORSE_INFO", "VALIDATION", false,
-                    "Player " + player.getName() + " is not holding an item with meta.");
+                    "Player " + player.getName() + " has no inspectable item and is not riding a supported mount.");
             return true;
-        }
-
-        ItemMeta meta = item.getItemMeta();
-        PersistentDataContainer container = meta.getPersistentDataContainer();
-
-        player.sendMessage(ChatColor.GOLD + "------ BetterHorses Item Debug ------");
-        player.sendMessage(ChatColor.YELLOW + "Type: " + ChatColor.WHITE + item.getType());
-        player.sendMessage(ChatColor.YELLOW + "Amount: " + ChatColor.WHITE + item.getAmount());
-        player.sendMessage(ChatColor.YELLOW + "Display Name: " + ChatColor.WHITE
-                + (meta.hasDisplayName() ? meta.getDisplayName() : "<none>"));
-        player.sendMessage(ChatColor.YELLOW + "Unbreakable: " + ChatColor.WHITE + meta.isUnbreakable());
-
-        if (meta instanceof Damageable damageable) {
-            player.sendMessage(ChatColor.YELLOW + "Damage: " + ChatColor.WHITE + damageable.getDamage());
-        }
-
-        player.sendMessage(ChatColor.YELLOW + "CustomModelData: " + ChatColor.WHITE
-                + (meta.hasCustomModelData() ? meta.getCustomModelData() : "<none>"));
-
-        if (meta.hasLore()) {
-            player.sendMessage(ChatColor.YELLOW + "Lore:");
-            for (String line : meta.getLore()) {
-                player.sendMessage(ChatColor.GRAY + "  - " + line);
-            }
-        } else {
-            player.sendMessage(ChatColor.YELLOW + "Lore: " + ChatColor.WHITE + "<none>");
-        }
-
-        if (!meta.getItemFlags().isEmpty()) {
-            player.sendMessage(ChatColor.YELLOW + "ItemFlags:");
-            for (ItemFlag itemFlag : meta.getItemFlags()) {
-                player.sendMessage(ChatColor.GRAY + "  - " + itemFlag.name());
-            }
-        } else {
-            player.sendMessage(ChatColor.YELLOW + "ItemFlags: " + ChatColor.WHITE + "<none>");
-        }
-
-        if (container.getKeys().isEmpty()) {
-            player.sendMessage(ChatColor.YELLOW + "PersistentData: " + ChatColor.WHITE + "<none>");
-            plugin.debugLog("HORSE_INFO", "PDC_SCAN", true,
-                    "Player " + player.getName() + " inspected item without custom PDC keys.");
-            return true;
-        }
-
-        player.sendMessage(ChatColor.YELLOW + "PersistentData:");
-        for (NamespacedKey key : container.getKeys()) {
-            String renderedValue = resolveValue(container, key);
-            player.sendMessage(ChatColor.GRAY + "  - " + key + ChatColor.WHITE + " = " + renderedValue);
         }
 
         plugin.debugLog("HORSE_INFO", "COMPLETE", true,
-                "Player " + player.getName() + " inspected item with " + container.getKeys().size() + " PDC keys.");
+                "Player " + player.getName() + " inspected item=" + inspectedItem + ", mountedHorse=" + inspectedMount + ".");
+        return true;
+    }
+
+    private static boolean inspectMountedHorse(Player player, BetterHorses plugin) {
+        Entity vehicle = player.getVehicle();
+        if (!(vehicle instanceof AbstractHorse horse)) {
+            return false;
+        }
+
+        PersistentDataContainer data = horse.getPersistentDataContainer();
+        player.sendMessage(ChatColor.GOLD + "------ BetterHorses Mounted Horse Debug ------");
+        player.sendMessage(ChatColor.YELLOW + "Entity: " + ChatColor.WHITE + horse.getType());
+        player.sendMessage(ChatColor.YELLOW + "UUID: " + ChatColor.WHITE + horse.getUniqueId());
+        player.sendMessage(ChatColor.YELLOW + "Tamed: " + ChatColor.WHITE + horse.isTamed());
+        player.sendMessage(ChatColor.YELLOW + "Owner: " + ChatColor.WHITE
+                + (horse.getOwner() == null ? "<none>" : horse.getOwner().getUniqueId()));
+
+        AttributeInstance maxHealth = horse.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+        AttributeInstance speed = horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+        AttributeInstance jump = horse.getAttribute(Attribute.HORSE_JUMP_STRENGTH);
+
+        player.sendMessage(ChatColor.YELLOW + "Health: " + ChatColor.WHITE + String.format("%.2f / %.2f",
+                horse.getHealth(), maxHealth == null ? 0.0 : maxHealth.getBaseValue()));
+        player.sendMessage(ChatColor.YELLOW + "Speed: " + ChatColor.WHITE
+                + (speed == null ? "<none>" : String.format("%.4f", speed.getBaseValue())));
+        player.sendMessage(ChatColor.YELLOW + "Jump: " + ChatColor.WHITE
+                + (jump == null ? "<none>" : String.format("%.4f", jump.getBaseValue())));
+        player.sendMessage(ChatColor.YELLOW + "Trait: " + ChatColor.WHITE
+                + data.getOrDefault(BetterHorseKeys.TRAIT, PersistentDataType.STRING, "<none>"));
+        player.sendMessage(ChatColor.YELLOW + "Gender: " + ChatColor.WHITE
+                + data.getOrDefault(BetterHorseKeys.GENDER, PersistentDataType.STRING, "<none>"));
+        player.sendMessage(ChatColor.YELLOW + "Growth Stage: " + ChatColor.WHITE
+                + data.getOrDefault(BetterHorseKeys.GROWTH_STAGE, PersistentDataType.INTEGER, -1));
+        plugin.debugLog("HORSE_INFO", "MOUNT_SCAN", true,
+                "Player " + player.getName() + " inspected mounted horse " + horse.getUniqueId() + ".");
         return true;
     }
 

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/RespawnCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/RespawnCommand.java
@@ -23,7 +23,9 @@ import org.bukkit.persistence.PersistentDataType;
 public class RespawnCommand {
 
     public static boolean spawnHorseFromItem(Player player) {
-        LanguageManager lang = BetterHorses.getInstance().getLang();
+        BetterHorses plugin = BetterHorses.getInstance();
+        LanguageManager lang = plugin.getLang();
+        plugin.debugLog("HORSE_RESPAWN", "START", true, "Player " + player.getName() + " requested item spawn.");
 
         ItemStack item = player.getInventory().getItemInMainHand();
         String configuredItem = BetterHorses.getInstance().getConfig().getString("settings.horse-item", "SADDLE");
@@ -33,6 +35,7 @@ public class RespawnCommand {
 
         if (item == null || item.getType() != expectedMaterial || !item.hasItemMeta()) {
             player.sendMessage(lang.get("messages.invalid-item"));
+            plugin.debugLog("HORSE_RESPAWN", "VALIDATION", false, "Invalid item used by " + player.getName() + ".");
             return true;
         }
 
@@ -64,11 +67,13 @@ public class RespawnCommand {
 
         if (health == null || speed == null || jump == null || gender == null) {
             player.sendMessage(lang.getFormatted("messages.invalid-horse-data", "%mount%", mountName));
+            plugin.debugLog("HORSE_RESPAWN", "DATA", false, "Missing critical horse data for " + player.getName() + ".");
             return true;
         }
 
         if (!mountType.isEnabled(BetterHorses.getInstance().getConfig())) {
             player.sendMessage(lang.getFormatted("messages.invalid-horse-data", "%mount%", mountName));
+            plugin.debugLog("HORSE_RESPAWN", "MOUNT_TYPE", false, "Mount type disabled: " + mountType.getEntityType());
             return true;
         }
 
@@ -77,11 +82,13 @@ public class RespawnCommand {
             horse = mountType.spawn(player.getLocation());
         } catch (Exception e) {
             player.sendMessage(lang.get("messages.cant-spawn"));
+            plugin.debugLog("HORSE_RESPAWN", "SPAWN", false, "Mount spawn failed with exception: " + e.getMessage());
             return true;
         }
 
         if (horse == null || !horse.isValid()) {
             player.sendMessage(lang.get("messages.cant-spawn"));
+            plugin.debugLog("HORSE_RESPAWN", "SPAWN", false, "Spawn returned invalid entity for " + player.getName() + ".");
             return true;
         }
 
@@ -155,6 +162,7 @@ public class RespawnCommand {
         item.setAmount(item.getAmount() - 1);
         BetterHorsesAPI.callSpawnEvent(horse, item, BetterHorseSpawnEvent.SpawnCause.ITEM);
         player.sendMessage(lang.getFormatted("messages.horse-respawned", "%mount%", mountName));
+        plugin.debugLog("HORSE_RESPAWN", "COMPLETE", true, "Player " + player.getName() + " spawned " + mountName + ".");
         return true;
     }
 

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseSpawnListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseSpawnListener.java
@@ -27,10 +27,12 @@ public class HorseSpawnListener implements Listener {
 
     @EventHandler
     public void onHorseSpawn(CreatureSpawnEvent event) {
+        BetterHorses plugin = BetterHorses.getInstance();
         if (!(event.getEntity() instanceof AbstractHorse horse)) return;
         SupportedMountType mountType = SupportedMountType.fromEntity(horse).orElse(null);
-        if (mountType == null || !mountType.isEnabled(BetterHorses.getInstance().getConfig())) return;
+        if (mountType == null || !mountType.isEnabled(plugin.getConfig())) return;
         if (event.getSpawnReason() != CreatureSpawnEvent.SpawnReason.NATURAL) return;
+        plugin.debugLog("HORSE_SPAWN", "NATURAL", true, "Natural mount spawn detected for " + horse.getUniqueId() + ".");
 
         // Set gender
         String gender = GENDERS[random.nextInt(GENDERS.length)];
@@ -74,5 +76,6 @@ public class HorseSpawnListener implements Listener {
 
         data.set(growthKey, PersistentDataType.INTEGER, stage);
         BetterHorsesAPI.callSpawnEvent(horse, null, BetterHorseSpawnEvent.SpawnCause.NATURAL);
+        plugin.debugLog("HORSE_SPAWN", "COMPLETE", true, "Initialized natural mount " + horse.getUniqueId() + " stage=" + stage + ".");
     }
 }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/TraitActivationListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/TraitActivationListener.java
@@ -22,6 +22,7 @@ public class TraitActivationListener implements Listener {
     @EventHandler
     public void onTraitKeyPressed(PlayerSwapHandItemsEvent event) {
         Player player = event.getPlayer();
+        BetterHorses plugin = BetterHorses.getInstance();
         Entity vehicle = player.getVehicle();
 
         if (!(vehicle instanceof AbstractHorse mount)) return;
@@ -36,11 +37,13 @@ public class TraitActivationListener implements Listener {
         BetterHorseAbilityUseEvent abilityEvent = new BetterHorseAbilityUseEvent(player, mount, trait.toLowerCase());
         Bukkit.getPluginManager().callEvent(abilityEvent);
         if (abilityEvent.isCancelled()) {
+            plugin.debugLog("TRAIT_ACTIVATION", "EVENT", false, "Ability use cancelled for " + player.getName() + " trait=" + trait + ".");
             event.setCancelled(true);
             return;
         }
 
         String selectedTrait = abilityEvent.getTraitKey();
+        plugin.debugLog("TRAIT_ACTIVATION", "TRIGGER", true, "Player " + player.getName() + " activated trait " + selectedTrait + ".");
         switch (selectedTrait.toLowerCase()) {
             case "hellmare":
                 TraitRegistry.activateHellmare(player, mount);


### PR DESCRIPTION
### Motivation
- Add comprehensive debug instrumentation across the plugin so feature usage, lifecycle events and failure cases are traceable via the existing `debugLog` facility. 
- Extend the `/horse info` command to report information about a horse the player is currently riding, not only the horse item in-hand.

### Description
- Added structured debug checkpoints to plugin lifecycle and configuration paths in `BetterHorses` (startup, reload, alias refresh and listener registration). (file: `BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java`).
- Instrumented API and event flows in `BetterHorsesAPI` to log item-creation entry/exit, chosen material, inventory placement, and spawn/despawn event dispatch/results. (file: `BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java`).
- Added debug logging to main command and flow points: `/horsecreate` (`CustomHorseCommand`), despawn (`DespawnCommand`), and respawn/spawn from item (`RespawnCommand`) including validation failures and success completions. (files: `BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/*.java`).
- Extended `/horse info` behavior to inspect either the horse item in-hand or the horse the player is currently mounted on and print entity info (UUID, owner, tamed, health/speed/jump, trait, gender, growth stage); the command now succeeds if either source is present. (file: `BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseInfoCommand.java`).
- Added listener-level debug points for natural horse spawns and trait activation/cancel paths. (files: `BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseSpawnListener.java`, `.../TraitActivationListener.java`).
- Commit recorded as `b383271` including changes across 8 files.

### Testing
- Ran the project's test task with `./gradlew test` and it failed before compilation due to a Java/Gradle toolchain incompatibility (`Unsupported class file major version 69`), so unit/integration tests could not be executed in this environment.  
- No additional automated tests were run inside the container because the toolchain prevented JVM compilation/execution; local validation with a matching Java/Gradle runtime is recommended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b19909e3c0832bbb68fccb1d2f46f7)