### PR TITLE
Add configurable Training system (Riding, Brushing, Feeding) for horses

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
@@ -139,6 +139,8 @@ public class BetterHorses extends JavaPlugin {
         pluginManager.registerEvents(new HorseFeedListener(), this);
         pluginManager.registerEvents(new HorseItemBlockerListener(), this);
         pluginManager.registerEvents(new HorseMountListener(), this);
+        pluginManager.registerEvents(new HorseTrainingRidingListener(), this);
+        pluginManager.registerEvents(new HorseTrainingBrushingListener(), this);
         debugLog("LISTENER", "REGISTER_BASE", true, "Registered core horse listeners.");
 
         if (config.getBoolean("settings.allow-rightclick-spawn", true)) {

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorseKeys.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorseKeys.java
@@ -26,6 +26,13 @@ public final class BetterHorseKeys {
     public static final NamespacedKey COOLDOWN = key("cooldown");
     public static final NamespacedKey SADDLE = key("saddle");
     public static final NamespacedKey ARMOR = key("armor");
+    public static final NamespacedKey BASE_HEALTH = key("base_health");
+    public static final NamespacedKey BASE_SPEED = key("base_speed");
+    public static final NamespacedKey BASE_JUMP = key("base_jump");
+    public static final NamespacedKey TRAINING_RIDING_UNITS = key("training_riding_units");
+    public static final NamespacedKey TRAINING_BRUSHING_UNITS = key("training_brushing_units");
+    public static final NamespacedKey TRAINING_FEEDING_UNITS = key("training_feeding_units");
+    public static final NamespacedKey TRAINING_BRUSH_COOLDOWN = key("training_brush_cooldown");
 
     private static NamespacedKey key(String key) {
         return new NamespacedKey(BetterHorses.getInstance(), key);

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/DespawnCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/DespawnCommand.java
@@ -4,6 +4,8 @@ import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.api.BetterHorsesAPI;
 import me.luisgamedev.betterhorses.language.LanguageManager;
 import me.luisgamedev.betterhorses.traits.TraitRegistry;
+import me.luisgamedev.betterhorses.training.TrainingManager;
+import me.luisgamedev.betterhorses.api.BetterHorseKeys;
 import me.luisgamedev.betterhorses.utils.AttributeResolver;
 import me.luisgamedev.betterhorses.utils.HorseArmorUtils;
 import me.luisgamedev.betterhorses.utils.MountConfig;
@@ -97,6 +99,7 @@ public class DespawnCommand {
         String genderSymbol = gender.equalsIgnoreCase("male") ? lang.getRaw("messages.gender-male") : gender.equalsIgnoreCase("female") ? lang.getRaw("messages.gender-female") : "?";
 
         TraitRegistry.revertDashBoostIfActive(horse);
+        TrainingManager.ensureBaseStats(horse);
 
         double maxHealth = horse.getAttribute(AttributeResolver.generic("MAX_HEALTH")).getBaseValue();
         double currentHealth = horse.getHealth();
@@ -129,6 +132,7 @@ public class DespawnCommand {
         lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-speed", "%value%", String.format("%.4f", speed)));
         lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-jump", "%value%", String.format("%.4f", jump)));
         lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-growth", "%value%", String.format("%d", growthStage)));
+        lore.addAll(TrainingManager.getTrainingLoreLines(horse));
 
         if (trait != null) {
             lore.add(ChatColor.GOLD + lang.getFormattedRaw("messages.trait-line", "%trait%", formatTraitName(trait)));
@@ -146,6 +150,12 @@ public class DespawnCommand {
         itemData.set(new NamespacedKey(BetterHorses.getInstance(), "current_health"), PersistentDataType.DOUBLE, currentHealth);
         itemData.set(new NamespacedKey(BetterHorses.getInstance(), "speed"), PersistentDataType.DOUBLE, speed);
         itemData.set(new NamespacedKey(BetterHorses.getInstance(), "jump"), PersistentDataType.DOUBLE, jump);
+        itemData.set(BetterHorseKeys.BASE_HEALTH, PersistentDataType.DOUBLE, data.getOrDefault(BetterHorseKeys.BASE_HEALTH, PersistentDataType.DOUBLE, maxHealth));
+        itemData.set(BetterHorseKeys.BASE_SPEED, PersistentDataType.DOUBLE, data.getOrDefault(BetterHorseKeys.BASE_SPEED, PersistentDataType.DOUBLE, speed));
+        itemData.set(BetterHorseKeys.BASE_JUMP, PersistentDataType.DOUBLE, data.getOrDefault(BetterHorseKeys.BASE_JUMP, PersistentDataType.DOUBLE, jump));
+        itemData.set(BetterHorseKeys.TRAINING_RIDING_UNITS, PersistentDataType.DOUBLE, data.getOrDefault(BetterHorseKeys.TRAINING_RIDING_UNITS, PersistentDataType.DOUBLE, 0.0));
+        itemData.set(BetterHorseKeys.TRAINING_BRUSHING_UNITS, PersistentDataType.DOUBLE, data.getOrDefault(BetterHorseKeys.TRAINING_BRUSHING_UNITS, PersistentDataType.DOUBLE, 0.0));
+        itemData.set(BetterHorseKeys.TRAINING_FEEDING_UNITS, PersistentDataType.DOUBLE, data.getOrDefault(BetterHorseKeys.TRAINING_FEEDING_UNITS, PersistentDataType.DOUBLE, 0.0));
         itemData.set(new NamespacedKey(BetterHorses.getInstance(), "owner"), PersistentDataType.STRING, player.getUniqueId().toString());
         itemData.set(new NamespacedKey(BetterHorses.getInstance(), "style"), PersistentDataType.STRING, style.name());
         itemData.set(new NamespacedKey(BetterHorses.getInstance(), "color"), PersistentDataType.STRING, color.name());

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseFeedListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseFeedListener.java
@@ -1,6 +1,7 @@
 package me.luisgamedev.betterhorses.listeners;
 
 import me.luisgamedev.betterhorses.BetterHorses;
+import me.luisgamedev.betterhorses.training.TrainingManager;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -13,7 +14,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 
-import java.util.Locale;
 
 public class HorseFeedListener implements Listener {
 
@@ -41,6 +41,8 @@ public class HorseFeedListener implements Listener {
 
         if (!isFood) return;
 
+        final double feedingTrainingValue = TrainingManager.getFoodTrainingValue(type);
+
         final FileConfiguration config = BetterHorses.getInstance().getConfig();
 
         if (!horse.isAdult() && config.getBoolean("horse-growth-settings.enabled", false)) {
@@ -51,7 +53,12 @@ public class HorseFeedListener implements Listener {
         if (!horse.isTamed()) return;
 
         final long cooldownSeconds = config.getLong("settings.breeding-cooldown", 0L);
-        if (cooldownSeconds <= 0L) return;
+        if (cooldownSeconds <= 0L) {
+            if (feedingTrainingValue > 0) {
+                TrainingManager.addFeedingUnits(horse, feedingTrainingValue);
+            }
+            return;
+        }
 
         final long cooldownMillis = cooldownSeconds * 1000L;
         final long now = System.currentTimeMillis();
@@ -61,6 +68,9 @@ public class HorseFeedListener implements Listener {
             final String gender = data.getOrDefault(genderKey, PersistentDataType.STRING, "UNKNOWN");
             if ("male".equalsIgnoreCase(gender)) {
                 horse.setAge(0);
+                if (feedingTrainingValue > 0) {
+                    TrainingManager.addFeedingUnits(horse, feedingTrainingValue);
+                }
                 return;
             }
         }
@@ -78,6 +88,10 @@ public class HorseFeedListener implements Listener {
             } else {
                 data.remove(cooldownKey);
             }
+        }
+
+        if (!event.isCancelled() && feedingTrainingValue > 0) {
+            TrainingManager.addFeedingUnits(horse, feedingTrainingValue);
         }
     }
 }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseSpawnListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseSpawnListener.java
@@ -3,6 +3,7 @@ package me.luisgamedev.betterhorses.listeners;
 import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.api.BetterHorsesAPI;
 import me.luisgamedev.betterhorses.api.events.BetterHorseSpawnEvent;
+import me.luisgamedev.betterhorses.training.TrainingManager;
 import me.luisgamedev.betterhorses.utils.MountConfig;
 import me.luisgamedev.betterhorses.utils.SupportedMountType;
 import org.bukkit.NamespacedKey;
@@ -75,6 +76,8 @@ public class HorseSpawnListener implements Listener {
         }
 
         data.set(growthKey, PersistentDataType.INTEGER, stage);
+        TrainingManager.ensureBaseStats(horse);
+        TrainingManager.recalculateAndApplyBonuses(horse);
         BetterHorsesAPI.callSpawnEvent(horse, null, BetterHorseSpawnEvent.SpawnCause.NATURAL);
         plugin.debugLog("HORSE_SPAWN", "COMPLETE", true, "Initialized natural mount " + horse.getUniqueId() + " stage=" + stage + ".");
     }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseTrainingBrushingListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseTrainingBrushingListener.java
@@ -1,0 +1,47 @@
+package me.luisgamedev.betterhorses.listeners;
+
+import me.luisgamedev.betterhorses.BetterHorses;
+import me.luisgamedev.betterhorses.api.BetterHorseKeys;
+import me.luisgamedev.betterhorses.training.TrainingManager;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.AbstractHorse;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+public class HorseTrainingBrushingListener implements Listener {
+
+    @EventHandler(ignoreCancelled = true)
+    public void onBrush(PlayerInteractEntityEvent event) {
+        if (!(event.getRightClicked() instanceof AbstractHorse horse)) return;
+
+        FileConfiguration config = BetterHorses.getInstance().getConfig();
+        if (!TrainingManager.isTrainingEnabled(config) || !TrainingManager.isCategoryEnabled(config, "brushing")) return;
+
+        Player player = event.getPlayer();
+        ItemStack item = player.getInventory().getItem(event.getHand());
+        if (item == null || item.getType() == Material.AIR) return;
+
+        Material brushMaterial = Material.matchMaterial(config.getString("training.categories.brushing.item", "BRUSH"));
+        if (brushMaterial == null) brushMaterial = Material.BRUSH;
+        if (item.getType() != brushMaterial) return;
+
+        long cooldownMillis = Math.max(0L, config.getLong("training.categories.brushing.cooldown-seconds", 180L) * 1000L);
+        PersistentDataContainer data = horse.getPersistentDataContainer();
+        long now = System.currentTimeMillis();
+        long lastBrush = data.getOrDefault(BetterHorseKeys.TRAINING_BRUSH_COOLDOWN, PersistentDataType.LONG, 0L);
+
+        if (cooldownMillis > 0L && now - lastBrush < cooldownMillis) {
+            return;
+        }
+
+        data.set(BetterHorseKeys.TRAINING_BRUSH_COOLDOWN, PersistentDataType.LONG, now);
+        double units = config.getDouble("training.categories.brushing.units-per-use", 1.0);
+        TrainingManager.addBrushingUnits(horse, units);
+    }
+}

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseTrainingRidingListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseTrainingRidingListener.java
@@ -1,0 +1,23 @@
+package me.luisgamedev.betterhorses.listeners;
+
+import me.luisgamedev.betterhorses.training.TrainingManager;
+import org.bukkit.entity.AbstractHorse;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerMoveEvent;
+
+public class HorseTrainingRidingListener implements Listener {
+
+    @EventHandler(ignoreCancelled = true)
+    public void onMove(PlayerMoveEvent event) {
+        Player player = event.getPlayer();
+        if (!(player.getVehicle() instanceof AbstractHorse horse)) return;
+        if (event.getTo() == null || event.getFrom().getWorld() != event.getTo().getWorld()) return;
+
+        double distance = event.getFrom().distance(event.getTo());
+        if (distance <= 0.0D) return;
+
+        TrainingManager.addRidingUnits(horse, distance);
+    }
+}

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RightClickListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RightClickListener.java
@@ -4,6 +4,8 @@ import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.api.BetterHorsesAPI;
 import me.luisgamedev.betterhorses.api.events.BetterHorseSpawnEvent;
 import me.luisgamedev.betterhorses.language.LanguageManager;
+import me.luisgamedev.betterhorses.training.TrainingManager;
+import me.luisgamedev.betterhorses.api.BetterHorseKeys;
 import me.luisgamedev.betterhorses.utils.AttributeResolver;
 import me.luisgamedev.betterhorses.utils.HorseArmorUtils;
 import me.luisgamedev.betterhorses.utils.MountConfig;
@@ -59,6 +61,12 @@ public class RightClickListener implements Listener {
         Double currentHealth = data.get(new NamespacedKey(BetterHorses.getInstance(), "current_health"), PersistentDataType.DOUBLE);
         Double speed = data.get(new NamespacedKey(BetterHorses.getInstance(), "speed"), PersistentDataType.DOUBLE);
         Double jump = data.get(new NamespacedKey(BetterHorses.getInstance(), "jump"), PersistentDataType.DOUBLE);
+        Double baseHealth = data.get(BetterHorseKeys.BASE_HEALTH, PersistentDataType.DOUBLE);
+        Double baseSpeed = data.get(BetterHorseKeys.BASE_SPEED, PersistentDataType.DOUBLE);
+        Double baseJump = data.get(BetterHorseKeys.BASE_JUMP, PersistentDataType.DOUBLE);
+        Double ridingUnits = data.get(BetterHorseKeys.TRAINING_RIDING_UNITS, PersistentDataType.DOUBLE);
+        Double brushingUnits = data.get(BetterHorseKeys.TRAINING_BRUSHING_UNITS, PersistentDataType.DOUBLE);
+        Double feedingUnits = data.get(BetterHorseKeys.TRAINING_FEEDING_UNITS, PersistentDataType.DOUBLE);
         String gender = data.get(new NamespacedKey(BetterHorses.getInstance(), "gender"), PersistentDataType.STRING);
         String ownerUUID = player.getUniqueId().toString();
         String styleStr = data.get(new NamespacedKey(BetterHorses.getInstance(), "style"), PersistentDataType.STRING);
@@ -135,6 +143,12 @@ public class RightClickListener implements Listener {
         horseData.set(new NamespacedKey(BetterHorses.getInstance(), "gender"), PersistentDataType.STRING, gender);
         horseData.set(new NamespacedKey(BetterHorses.getInstance(), "growth_stage"), PersistentDataType.INTEGER, growthStage == 0 ? 10 : growthStage);
         horseData.set(new NamespacedKey(BetterHorses.getInstance(), "mount_type"), PersistentDataType.STRING, mountType.getEntityType().name());
+        horseData.set(BetterHorseKeys.BASE_HEALTH, PersistentDataType.DOUBLE, baseHealth != null ? baseHealth : health);
+        horseData.set(BetterHorseKeys.BASE_SPEED, PersistentDataType.DOUBLE, baseSpeed != null ? baseSpeed : speed);
+        horseData.set(BetterHorseKeys.BASE_JUMP, PersistentDataType.DOUBLE, baseJump != null ? baseJump : jump);
+        horseData.set(BetterHorseKeys.TRAINING_RIDING_UNITS, PersistentDataType.DOUBLE, ridingUnits != null ? ridingUnits : 0.0);
+        horseData.set(BetterHorseKeys.TRAINING_BRUSHING_UNITS, PersistentDataType.DOUBLE, brushingUnits != null ? brushingUnits : 0.0);
+        horseData.set(BetterHorseKeys.TRAINING_FEEDING_UNITS, PersistentDataType.DOUBLE, feedingUnits != null ? feedingUnits : 0.0);
 
         if (trait != null && !trait.isBlank()) {
             horseData.set(new NamespacedKey(BetterHorses.getInstance(), "trait"), PersistentDataType.STRING, trait);
@@ -166,6 +180,8 @@ public class RightClickListener implements Listener {
         if (armorStr != null) {
             HorseArmorUtils.setArmor(horse.getInventory(), new ItemStack(Material.valueOf(armorStr)));
         }
+
+        TrainingManager.recalculateAndApplyBonuses(horse);
 
         item.setAmount(item.getAmount() - 1);
         player.sendMessage(lang.getFormatted("messages.horse-respawned", "%mount%", mountName));

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java
@@ -1,0 +1,179 @@
+package me.luisgamedev.betterhorses.training;
+
+import me.luisgamedev.betterhorses.BetterHorses;
+import me.luisgamedev.betterhorses.api.BetterHorseKeys;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.AbstractHorse;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class TrainingManager {
+
+    private TrainingManager() {}
+
+    public static boolean isTrainingEnabled(FileConfiguration config) {
+        return config.getBoolean("training.enabled", false);
+    }
+
+    public static boolean isCategoryEnabled(FileConfiguration config, String category) {
+        return config.getBoolean("training.categories." + category + ".enabled", true);
+    }
+
+    public static void ensureBaseStats(AbstractHorse horse) {
+        PersistentDataContainer data = horse.getPersistentDataContainer();
+        saveBaseIfMissing(horse, data, Attribute.GENERIC_MAX_HEALTH, BetterHorseKeys.BASE_HEALTH);
+        saveBaseIfMissing(horse, data, Attribute.GENERIC_MOVEMENT_SPEED, BetterHorseKeys.BASE_SPEED);
+        saveBaseIfMissing(horse, data, Attribute.HORSE_JUMP_STRENGTH, BetterHorseKeys.BASE_JUMP);
+    }
+
+    public static void addRidingUnits(AbstractHorse horse, double units) {
+        if (units <= 0) return;
+        FileConfiguration config = BetterHorses.getInstance().getConfig();
+        if (!isTrainingEnabled(config) || !isCategoryEnabled(config, "riding")) return;
+
+        PersistentDataContainer data = horse.getPersistentDataContainer();
+        double current = data.getOrDefault(BetterHorseKeys.TRAINING_RIDING_UNITS, PersistentDataType.DOUBLE, 0.0);
+        data.set(BetterHorseKeys.TRAINING_RIDING_UNITS, PersistentDataType.DOUBLE, current + units);
+        recalculateAndApplyBonuses(horse);
+    }
+
+    public static void addBrushingUnits(AbstractHorse horse, double units) {
+        if (units <= 0) return;
+        FileConfiguration config = BetterHorses.getInstance().getConfig();
+        if (!isTrainingEnabled(config) || !isCategoryEnabled(config, "brushing")) return;
+
+        PersistentDataContainer data = horse.getPersistentDataContainer();
+        double current = data.getOrDefault(BetterHorseKeys.TRAINING_BRUSHING_UNITS, PersistentDataType.DOUBLE, 0.0);
+        data.set(BetterHorseKeys.TRAINING_BRUSHING_UNITS, PersistentDataType.DOUBLE, current + units);
+        recalculateAndApplyBonuses(horse);
+    }
+
+    public static void addFeedingUnits(AbstractHorse horse, double units) {
+        if (units <= 0) return;
+        FileConfiguration config = BetterHorses.getInstance().getConfig();
+        if (!isTrainingEnabled(config) || !isCategoryEnabled(config, "feeding")) return;
+
+        PersistentDataContainer data = horse.getPersistentDataContainer();
+        double current = data.getOrDefault(BetterHorseKeys.TRAINING_FEEDING_UNITS, PersistentDataType.DOUBLE, 0.0);
+        data.set(BetterHorseKeys.TRAINING_FEEDING_UNITS, PersistentDataType.DOUBLE, current + units);
+        recalculateAndApplyBonuses(horse);
+    }
+
+    public static void recalculateAndApplyBonuses(AbstractHorse horse) {
+        FileConfiguration config = BetterHorses.getInstance().getConfig();
+        PersistentDataContainer data = horse.getPersistentDataContainer();
+
+        ensureBaseStats(horse);
+
+        double baseHealth = data.getOrDefault(BetterHorseKeys.BASE_HEALTH, PersistentDataType.DOUBLE, readAttribute(horse, Attribute.GENERIC_MAX_HEALTH));
+        double baseSpeed = data.getOrDefault(BetterHorseKeys.BASE_SPEED, PersistentDataType.DOUBLE, readAttribute(horse, Attribute.GENERIC_MOVEMENT_SPEED));
+        double baseJump = data.getOrDefault(BetterHorseKeys.BASE_JUMP, PersistentDataType.DOUBLE, readAttribute(horse, Attribute.HORSE_JUMP_STRENGTH));
+
+        double ridingPercent = getProgressPercent(config, data, "riding", BetterHorseKeys.TRAINING_RIDING_UNITS);
+        double brushingPercent = getProgressPercent(config, data, "brushing", BetterHorseKeys.TRAINING_BRUSHING_UNITS);
+        double feedingPercent = getProgressPercent(config, data, "feeding", BetterHorseKeys.TRAINING_FEEDING_UNITS);
+
+        double speedBonusPerPercent = config.getDouble("training.categories.riding.bonus-percent-per-progress-percent", 0.2);
+        double jumpBonusPerPercent = config.getDouble("training.categories.brushing.bonus-percent-per-progress-percent", 0.2);
+        double healthBonusPerPercent = config.getDouble("training.categories.feeding.bonus-percent-per-progress-percent", 0.2);
+
+        double boostedSpeed = baseSpeed * (1.0 + (ridingPercent * speedBonusPerPercent / 100.0));
+        double boostedJump = baseJump * (1.0 + (brushingPercent * jumpBonusPerPercent / 100.0));
+        double boostedHealth = baseHealth * (1.0 + (feedingPercent * healthBonusPerPercent / 100.0));
+
+        setAttribute(horse, Attribute.GENERIC_MOVEMENT_SPEED, boostedSpeed);
+        setAttribute(horse, Attribute.HORSE_JUMP_STRENGTH, boostedJump);
+
+        double oldHealth = readAttribute(horse, Attribute.GENERIC_MAX_HEALTH);
+        setAttribute(horse, Attribute.GENERIC_MAX_HEALTH, boostedHealth);
+        if (oldHealth > 0) {
+            double ratio = horse.getHealth() / oldHealth;
+            horse.setHealth(Math.max(1.0, Math.min(boostedHealth, boostedHealth * ratio)));
+        }
+    }
+
+    public static double getFoodTrainingValue(Material material) {
+        FileConfiguration config = BetterHorses.getInstance().getConfig();
+        ConfigurationSection section = config.getConfigurationSection("training.categories.feeding.food-values");
+        if (section == null) return 0.0;
+        return section.getDouble(material.name(), 0.0);
+    }
+
+    public static List<String> getTrainingLoreLines(AbstractHorse horse) {
+        FileConfiguration config = BetterHorses.getInstance().getConfig();
+        List<String> lines = new ArrayList<>();
+        if (!isTrainingEnabled(config)) return lines;
+
+        lines.add(color(config.getString("training.lore.title", "&6Training")));
+        addCategoryLore(lines, config, horse, "riding", BetterHorseKeys.TRAINING_RIDING_UNITS, "&7Riding: &f%bar% &7(%percent%%)");
+        addCategoryLore(lines, config, horse, "brushing", BetterHorseKeys.TRAINING_BRUSHING_UNITS, "&7Brushing: &f%bar% &7(%percent%%)");
+        addCategoryLore(lines, config, horse, "feeding", BetterHorseKeys.TRAINING_FEEDING_UNITS, "&7Feeding: &f%bar% &7(%percent%%)");
+        return lines;
+    }
+
+    public static double getProgressPercent(FileConfiguration config, PersistentDataContainer data, String category, NamespacedKey unitsKey) {
+        if (!isTrainingEnabled(config) || !isCategoryEnabled(config, category)) return 0.0;
+        double units = data.getOrDefault(unitsKey, PersistentDataType.DOUBLE, 0.0);
+        double unitsPerPercent = Math.max(0.0001, config.getDouble("training.categories." + category + ".units-per-percent", 10.0));
+        return Math.max(0.0, Math.min(100.0, units / unitsPerPercent));
+    }
+
+    private static void addCategoryLore(List<String> lines, FileConfiguration config, AbstractHorse horse, String category, NamespacedKey key, String formatDefault) {
+        if (!isCategoryEnabled(config, category)) return;
+        PersistentDataContainer data = horse.getPersistentDataContainer();
+        double percent = getProgressPercent(config, data, category, key);
+        int rounded = (int) Math.round(percent);
+        String bar = progressBar(config, percent);
+        String format = config.getString("training.categories." + category + ".lore-format", formatDefault);
+        lines.add(color(format.replace("%bar%", bar).replace("%percent%", String.valueOf(rounded))));
+    }
+
+    private static String progressBar(FileConfiguration config, double percent) {
+        int length = Math.max(5, config.getInt("training.lore.progress-bar.length", 20));
+        char filledChar = config.getString("training.lore.progress-bar.filled-char", "|").charAt(0);
+        char emptyChar = config.getString("training.lore.progress-bar.empty-char", "|").charAt(0);
+        String filledColor = color(config.getString("training.lore.progress-bar.filled-color", "&a"));
+        String emptyColor = color(config.getString("training.lore.progress-bar.empty-color", "&7"));
+
+        int filled = (int) Math.round((percent / 100.0) * length);
+        StringBuilder builder = new StringBuilder();
+        builder.append(filledColor);
+        for (int i = 0; i < filled; i++) builder.append(filledChar);
+        builder.append(emptyColor);
+        for (int i = filled; i < length; i++) builder.append(emptyChar);
+        return builder.toString();
+    }
+
+    private static void saveBaseIfMissing(AbstractHorse horse, PersistentDataContainer data, Attribute attribute, NamespacedKey key) {
+        if (data.has(key, PersistentDataType.DOUBLE)) return;
+        AttributeInstance attr = horse.getAttribute(attribute);
+        if (attr != null) {
+            data.set(key, PersistentDataType.DOUBLE, attr.getBaseValue());
+        }
+    }
+
+    private static double readAttribute(AbstractHorse horse, Attribute attribute) {
+        AttributeInstance attr = horse.getAttribute(attribute);
+        return attr != null ? attr.getBaseValue() : 0.0;
+    }
+
+    private static void setAttribute(AbstractHorse horse, Attribute attribute, double value) {
+        AttributeInstance attr = horse.getAttribute(attribute);
+        if (attr != null) {
+            attr.setBaseValue(value);
+        }
+    }
+
+    private static String color(String value) {
+        return ChatColor.translateAlternateColorCodes('&', value == null ? "" : value);
+    }
+}

--- a/BetterHorses/src/main/resources/config.yml
+++ b/BetterHorses/src/main/resources/config.yml
@@ -177,3 +177,54 @@ traits:
     chance: 0.001 # 0.1%
     strength: 0.4
     particles: true
+
+# Horse training system
+training:
+  # Master toggle for all training categories
+  enabled: true
+
+  lore:
+    title: "&6Training"
+    progress-bar:
+      length: 20
+      filled-char: "|"
+      empty-char: "|"
+      filled-color: "&a"
+      empty-color: "&7"
+
+  categories:
+    riding:
+      enabled: true
+      # 1% progress = this many blocks ridden
+      units-per-percent: 25.0
+      # 0.2 means +0.2% speed per 1% progress
+      bonus-percent-per-progress-percent: 0.2
+      lore-format: "&7Riding: %bar% &7(%percent%%)"
+
+    brushing:
+      enabled: true
+      item: BRUSH
+      cooldown-seconds: 180
+      units-per-use: 1.0
+      # 1% progress = this many brush uses (units)
+      units-per-percent: 1.0
+      # 0.2 means +0.2% jump strength per 1% progress
+      bonus-percent-per-progress-percent: 0.2
+      lore-format: "&7Brushing: %bar% &7(%percent%%)"
+
+    feeding:
+      enabled: true
+      # 1% progress = this much total food value
+      units-per-percent: 2.0
+      # 0.2 means +0.2% max HP per 1% progress
+      bonus-percent-per-progress-percent: 0.2
+      lore-format: "&7Feeding: %bar% &7(%percent%%)"
+      food-values:
+        WHEAT: 1.0
+        APPLE: 1.0
+        CARROT: 1.0
+        SUGAR: 1.0
+        HAY_BLOCK: 2.0
+        GOLDEN_CARROT: 3.0
+        GOLDEN_APPLE: 5.0
+        ENCHANTED_GOLDEN_APPLE: 8.0


### PR DESCRIPTION
### Motivation
- Implement a new horse `Training` feature that tracks progress in three categories (`Riding`, `Brushing`, `Feeding`) and grants configurable stat bonuses based on progress. 
- Persist training/base-stat data on horse items and display progress in the item lore so progress survives despawn/respawn and can be configured by server admins.

### Description
- Added a central `TrainingManager` (`me.luisgamedev.betterhorses.training.TrainingManager`) which stores progress units, calculates percent progress using configurable `units-per-percent`, applies bonuses, persists base stats, and renders lore progress bars.
- Added two new listeners: `HorseTrainingRidingListener` to grant riding units from distance ridden and `HorseTrainingBrushingListener` to grant brushing units when using a configured brush item with a cooldown.
- Integrated feeding into training via `HorseFeedListener` by mapping foods to configurable training values and awarding feeding units when feeding occurs.
- Persisted new namespaced keys in `BetterHorseKeys` for base stats and training state (`BASE_HEALTH`, `BASE_SPEED`, `BASE_JUMP`, `TRAINING_*`), updated `DespawnCommand` to write training metadata and lore, and updated `RightClickListener` and `HorseSpawnListener` to restore/apply training data on spawn.
- Extended `config.yml` with top-level `training.enabled`, per-category toggles under `training.categories.*`, `units-per-percent`, `bonus-percent-per-progress-percent`, brush `item` and `cooldown-seconds`, and `feeding.food-values`; lore formatting options and progress-bar settings are also included.

### Testing
- Attempted to run a build with `./gradlew build -x test`; the build environment failed before compilation with a Gradle/Groovy error `Unsupported class file major version 69`, so project compilation could not be completed in this environment.
- No plugin unit tests were executed; runtime behavior should be validated on a Paper server (Java matching project toolchain) to confirm listener registration, persistence, lore output, and stat-bonus application.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1be31b534832b88bb64879e7b7707)