### PR TITLE
Style training progress bars like compact cyan meter

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java
@@ -114,9 +114,9 @@ public final class TrainingManager {
         if (!isTrainingEnabled(config)) return lines;
 
         lines.add(color(config.getString("training.lore.title", "&6Training")));
-        addCategoryLore(lines, config, horse, "riding", BetterHorseKeys.TRAINING_RIDING_UNITS, "&7Riding: &f%bar% &7(%percent%%)");
-        addCategoryLore(lines, config, horse, "brushing", BetterHorseKeys.TRAINING_BRUSHING_UNITS, "&7Brushing: &f%bar% &7(%percent%%)");
-        addCategoryLore(lines, config, horse, "feeding", BetterHorseKeys.TRAINING_FEEDING_UNITS, "&7Feeding: &f%bar% &7(%percent%%)");
+        addCategoryLore(lines, config, horse, "riding", BetterHorseKeys.TRAINING_RIDING_UNITS, "&7Riding Progress: %bar% &b%percent%%");
+        addCategoryLore(lines, config, horse, "brushing", BetterHorseKeys.TRAINING_BRUSHING_UNITS, "&7Brushing Progress: %bar% &b%percent%%");
+        addCategoryLore(lines, config, horse, "feeding", BetterHorseKeys.TRAINING_FEEDING_UNITS, "&7Feeding Progress: %bar% &b%percent%%");
         return lines;
     }
 
@@ -139,10 +139,10 @@ public final class TrainingManager {
 
     private static String progressBar(FileConfiguration config, double percent) {
         int length = Math.max(5, config.getInt("training.lore.progress-bar.length", 20));
-        char filledChar = config.getString("training.lore.progress-bar.filled-char", "|").charAt(0);
-        char emptyChar = config.getString("training.lore.progress-bar.empty-char", "|").charAt(0);
-        String filledColor = color(config.getString("training.lore.progress-bar.filled-color", "&a"));
-        String emptyColor = color(config.getString("training.lore.progress-bar.empty-color", "&7"));
+        char filledChar = config.getString("training.lore.progress-bar.filled-char", "■").charAt(0);
+        char emptyChar = config.getString("training.lore.progress-bar.empty-char", "■").charAt(0);
+        String filledColor = color(config.getString("training.lore.progress-bar.filled-color", "&b"));
+        String emptyColor = color(config.getString("training.lore.progress-bar.empty-color", "&8"));
 
         int filled = (int) Math.round((percent / 100.0) * length);
         StringBuilder builder = new StringBuilder();

--- a/BetterHorses/src/main/resources/config.yml
+++ b/BetterHorses/src/main/resources/config.yml
@@ -187,10 +187,10 @@ training:
     title: "&6Training"
     progress-bar:
       length: 20
-      filled-char: "|"
-      empty-char: "|"
-      filled-color: "&a"
-      empty-color: "&7"
+      filled-char: "■"
+      empty-char: "■"
+      filled-color: "&b"
+      empty-color: "&8"
 
   categories:
     riding:
@@ -199,7 +199,7 @@ training:
       units-per-percent: 25.0
       # 0.2 means +0.2% speed per 1% progress
       bonus-percent-per-progress-percent: 0.2
-      lore-format: "&7Riding: %bar% &7(%percent%%)"
+      lore-format: "&7Riding Progress: %bar% &b%percent%%"
 
     brushing:
       enabled: true
@@ -210,7 +210,7 @@ training:
       units-per-percent: 1.0
       # 0.2 means +0.2% jump strength per 1% progress
       bonus-percent-per-progress-percent: 0.2
-      lore-format: "&7Brushing: %bar% &7(%percent%%)"
+      lore-format: "&7Brushing Progress: %bar% &b%percent%%"
 
     feeding:
       enabled: true
@@ -218,7 +218,7 @@ training:
       units-per-percent: 2.0
       # 0.2 means +0.2% max HP per 1% progress
       bonus-percent-per-progress-percent: 0.2
-      lore-format: "&7Feeding: %bar% &7(%percent%%)"
+      lore-format: "&7Feeding Progress: %bar% &b%percent%%"
       food-values:
         WHEAT: 1.0
         APPLE: 1.0


### PR DESCRIPTION
### Motivation
- Improve the visual appearance of the training progress indications so they match a compact cyan meter style shown in the example image.
- Make the defaults more readable and consistent between runtime fallbacks and the shipped configuration so new installs get the new look out of the box.

### Description
- Changed runtime fallback lore strings in `BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java` to use `* Progress` labels and show the percentage in cyan.
- Switched progress glyphs to a compact square block (`■`) and updated default colors to cyan (`&b`) for filled segments and dark gray (`&8`) for empty segments in `TrainingManager.java`.
- Mirrored the same visual defaults in `BetterHorses/src/main/resources/config.yml` so the shipped defaults match the new appearance.
- Modified files: `BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java` and `BetterHorses/src/main/resources/config.yml`.

### Testing
- Attempted to build the project with `./gradlew build` in `BetterHorses/`, which failed due to an environment/toolchain issue: `Unsupported class file major version 69`, unrelated to these code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1c1be3748832b8253fb5e2da02816)