### PR TITLE
Persist training progress in PDC and localize training lore to language.yml

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/DespawnCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/DespawnCommand.java
@@ -54,12 +54,12 @@ public class DespawnCommand {
         String mountName = mountType.getDisplayName(lang);
 
         PersistentDataContainer data = horse.getPersistentDataContainer();
-        NamespacedKey genderKey = new NamespacedKey(BetterHorses.getInstance(), "gender");
-        NamespacedKey ownerKey = new NamespacedKey(BetterHorses.getInstance(), "owner");
-        NamespacedKey traitKey = new NamespacedKey(BetterHorses.getInstance(), "trait");
-        NamespacedKey neuterKey = new NamespacedKey(BetterHorses.getInstance(), "neutered");
-        NamespacedKey growthKey = new NamespacedKey(BetterHorses.getInstance(), "growth_stage");
-        NamespacedKey cooldownKey = new NamespacedKey(BetterHorses.getInstance(), "cooldown");
+        NamespacedKey genderKey = BetterHorseKeys.GENDER;
+        NamespacedKey ownerKey = BetterHorseKeys.OWNER;
+        NamespacedKey traitKey = BetterHorseKeys.TRAIT;
+        NamespacedKey neuterKey = BetterHorseKeys.NEUTERED;
+        NamespacedKey growthKey = BetterHorseKeys.GROWTH_STAGE;
+        NamespacedKey cooldownKey = BetterHorseKeys.COOLDOWN;
 
         String storedOwner = data.get(ownerKey, PersistentDataType.STRING);
         boolean ownershipRequired = mountType != SupportedMountType.CAMEL || storedOwner != null;
@@ -144,23 +144,23 @@ public class DespawnCommand {
         meta.setLore(lore);
 
         if (horse.getCustomName() != null) {
-            itemData.set(new NamespacedKey(BetterHorses.getInstance(), "name"), PersistentDataType.STRING, horse.getCustomName());
+            itemData.set(BetterHorseKeys.NAME, PersistentDataType.STRING, horse.getCustomName());
         }
-        itemData.set(new NamespacedKey(BetterHorses.getInstance(), "health"), PersistentDataType.DOUBLE, maxHealth);
-        itemData.set(new NamespacedKey(BetterHorses.getInstance(), "current_health"), PersistentDataType.DOUBLE, currentHealth);
-        itemData.set(new NamespacedKey(BetterHorses.getInstance(), "speed"), PersistentDataType.DOUBLE, speed);
-        itemData.set(new NamespacedKey(BetterHorses.getInstance(), "jump"), PersistentDataType.DOUBLE, jump);
+        itemData.set(BetterHorseKeys.HEALTH, PersistentDataType.DOUBLE, maxHealth);
+        itemData.set(BetterHorseKeys.CURRENT_HEALTH, PersistentDataType.DOUBLE, currentHealth);
+        itemData.set(BetterHorseKeys.SPEED, PersistentDataType.DOUBLE, speed);
+        itemData.set(BetterHorseKeys.JUMP, PersistentDataType.DOUBLE, jump);
         itemData.set(BetterHorseKeys.BASE_HEALTH, PersistentDataType.DOUBLE, data.getOrDefault(BetterHorseKeys.BASE_HEALTH, PersistentDataType.DOUBLE, maxHealth));
         itemData.set(BetterHorseKeys.BASE_SPEED, PersistentDataType.DOUBLE, data.getOrDefault(BetterHorseKeys.BASE_SPEED, PersistentDataType.DOUBLE, speed));
         itemData.set(BetterHorseKeys.BASE_JUMP, PersistentDataType.DOUBLE, data.getOrDefault(BetterHorseKeys.BASE_JUMP, PersistentDataType.DOUBLE, jump));
         itemData.set(BetterHorseKeys.TRAINING_RIDING_UNITS, PersistentDataType.DOUBLE, data.getOrDefault(BetterHorseKeys.TRAINING_RIDING_UNITS, PersistentDataType.DOUBLE, 0.0));
         itemData.set(BetterHorseKeys.TRAINING_BRUSHING_UNITS, PersistentDataType.DOUBLE, data.getOrDefault(BetterHorseKeys.TRAINING_BRUSHING_UNITS, PersistentDataType.DOUBLE, 0.0));
         itemData.set(BetterHorseKeys.TRAINING_FEEDING_UNITS, PersistentDataType.DOUBLE, data.getOrDefault(BetterHorseKeys.TRAINING_FEEDING_UNITS, PersistentDataType.DOUBLE, 0.0));
-        itemData.set(new NamespacedKey(BetterHorses.getInstance(), "owner"), PersistentDataType.STRING, player.getUniqueId().toString());
-        itemData.set(new NamespacedKey(BetterHorses.getInstance(), "style"), PersistentDataType.STRING, style.name());
-        itemData.set(new NamespacedKey(BetterHorses.getInstance(), "color"), PersistentDataType.STRING, color.name());
-        itemData.set(new NamespacedKey(BetterHorses.getInstance(), "growth_stage"), PersistentDataType.INTEGER, growthStage);
-        itemData.set(new NamespacedKey(BetterHorses.getInstance(), "mount_type"), PersistentDataType.STRING, mountType.getEntityType().name());
+        itemData.set(BetterHorseKeys.OWNER, PersistentDataType.STRING, player.getUniqueId().toString());
+        itemData.set(BetterHorseKeys.STYLE, PersistentDataType.STRING, style.name());
+        itemData.set(BetterHorseKeys.COLOR, PersistentDataType.STRING, color.name());
+        itemData.set(BetterHorseKeys.GROWTH_STAGE, PersistentDataType.INTEGER, growthStage);
+        itemData.set(BetterHorseKeys.MOUNT_TYPE, PersistentDataType.STRING, mountType.getEntityType().name());
         if (trait != null) {
             itemData.set(traitKey, PersistentDataType.STRING, trait.toLowerCase());
         }
@@ -168,10 +168,10 @@ public class DespawnCommand {
             itemData.set(neuterKey, PersistentDataType.BYTE, (byte) 1);
         }
         if (cooldown != null) {
-            itemData.set(cooldownKey, PersistentDataType.LONG, cooldown);
+            itemData.set(BetterHorseKeys.COOLDOWN, PersistentDataType.LONG, cooldown);
         }
-        if (saddle != null) itemData.set(new NamespacedKey(BetterHorses.getInstance(), "saddle"), PersistentDataType.STRING, saddle.getType().name());
-        if (armor != null) itemData.set(new NamespacedKey(BetterHorses.getInstance(), "armor"), PersistentDataType.STRING, armor.getType().name());
+        if (saddle != null) itemData.set(BetterHorseKeys.SADDLE, PersistentDataType.STRING, saddle.getType().name());
+        if (armor != null) itemData.set(BetterHorseKeys.ARMOR, PersistentDataType.STRING, armor.getType().name());
 
         item.setItemMeta(meta);
         boolean wasLeashed = horse.isLeashed();

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/RespawnCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/RespawnCommand.java
@@ -2,6 +2,7 @@ package me.luisgamedev.betterhorses.commands;
 
 import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.api.BetterHorsesAPI;
+import me.luisgamedev.betterhorses.api.BetterHorseKeys;
 import me.luisgamedev.betterhorses.api.events.BetterHorseSpawnEvent;
 import me.luisgamedev.betterhorses.language.LanguageManager;
 import me.luisgamedev.betterhorses.utils.AttributeResolver;
@@ -9,7 +10,6 @@ import me.luisgamedev.betterhorses.utils.HorseArmorUtils;
 import me.luisgamedev.betterhorses.utils.MountConfig;
 import me.luisgamedev.betterhorses.utils.SupportedMountType;
 import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.AbstractHorse;
@@ -42,23 +42,23 @@ public class RespawnCommand {
         ItemMeta meta = item.getItemMeta();
         PersistentDataContainer data = meta.getPersistentDataContainer();
 
-        Double health = data.get(new NamespacedKey(BetterHorses.getInstance(), "health"), PersistentDataType.DOUBLE);
-        Double currentHealth = data.get(new NamespacedKey(BetterHorses.getInstance(), "current_health"), PersistentDataType.DOUBLE);
-        Double speed = data.get(new NamespacedKey(BetterHorses.getInstance(), "speed"), PersistentDataType.DOUBLE);
-        Double jump = data.get(new NamespacedKey(BetterHorses.getInstance(), "jump"), PersistentDataType.DOUBLE);
-        String gender = data.get(new NamespacedKey(BetterHorses.getInstance(), "gender"), PersistentDataType.STRING);
+        Double health = data.get(BetterHorseKeys.HEALTH, PersistentDataType.DOUBLE);
+        Double currentHealth = data.get(BetterHorseKeys.CURRENT_HEALTH, PersistentDataType.DOUBLE);
+        Double speed = data.get(BetterHorseKeys.SPEED, PersistentDataType.DOUBLE);
+        Double jump = data.get(BetterHorseKeys.JUMP, PersistentDataType.DOUBLE);
+        String gender = data.get(BetterHorseKeys.GENDER, PersistentDataType.STRING);
         String ownerUUID = player.getUniqueId().toString();
-        String styleStr = data.get(new NamespacedKey(BetterHorses.getInstance(), "style"), PersistentDataType.STRING);
-        String colorStr = data.get(new NamespacedKey(BetterHorses.getInstance(), "color"), PersistentDataType.STRING);
-        String saddleStr = data.get(new NamespacedKey(BetterHorses.getInstance(), "saddle"), PersistentDataType.STRING);
-        String armorStr = data.get(new NamespacedKey(BetterHorses.getInstance(), "armor"), PersistentDataType.STRING);
-        String customName = data.get(new NamespacedKey(BetterHorses.getInstance(), "name"), PersistentDataType.STRING);
-        String trait = data.get(new NamespacedKey(BetterHorses.getInstance(), "trait"), PersistentDataType.STRING);
-        Byte neutered = data.get(new NamespacedKey(BetterHorses.getInstance(), "neutered"), PersistentDataType.BYTE);
-        Integer storedStage = data.get(new NamespacedKey(BetterHorses.getInstance(), "growth_stage"), PersistentDataType.INTEGER);
-        String mountTypeName = data.get(new NamespacedKey(BetterHorses.getInstance(), "mount_type"), PersistentDataType.STRING);
-        Long cooldown = data.has(new NamespacedKey(BetterHorses.getInstance(), "cooldown"), PersistentDataType.LONG)
-                ? data.get(new NamespacedKey(BetterHorses.getInstance(), "cooldown"), PersistentDataType.LONG)
+        String styleStr = data.get(BetterHorseKeys.STYLE, PersistentDataType.STRING);
+        String colorStr = data.get(BetterHorseKeys.COLOR, PersistentDataType.STRING);
+        String saddleStr = data.get(BetterHorseKeys.SADDLE, PersistentDataType.STRING);
+        String armorStr = data.get(BetterHorseKeys.ARMOR, PersistentDataType.STRING);
+        String customName = data.get(BetterHorseKeys.NAME, PersistentDataType.STRING);
+        String trait = data.get(BetterHorseKeys.TRAIT, PersistentDataType.STRING);
+        Byte neutered = data.get(BetterHorseKeys.NEUTERED, PersistentDataType.BYTE);
+        Integer storedStage = data.get(BetterHorseKeys.GROWTH_STAGE, PersistentDataType.INTEGER);
+        String mountTypeName = data.get(BetterHorseKeys.MOUNT_TYPE, PersistentDataType.STRING);
+        Long cooldown = data.has(BetterHorseKeys.COOLDOWN, PersistentDataType.LONG)
+                ? data.get(BetterHorseKeys.COOLDOWN, PersistentDataType.LONG)
                 : null;
 
         int growthStage = storedStage != null ? storedStage : 10;
@@ -110,7 +110,7 @@ public class RespawnCommand {
         }
 
         horse.getPersistentDataContainer().set(
-                new NamespacedKey(BetterHorses.getInstance(), "growth_stage"),
+                BetterHorseKeys.GROWTH_STAGE,
                 PersistentDataType.INTEGER,
                 growthStage
         );
@@ -124,20 +124,33 @@ public class RespawnCommand {
 
         PersistentDataContainer horseData = horse.getPersistentDataContainer();
 
-        horseData.set(new NamespacedKey(BetterHorses.getInstance(), "owner"), PersistentDataType.STRING, ownerUUID);
-        horseData.set(new NamespacedKey(BetterHorses.getInstance(), "gender"), PersistentDataType.STRING, gender);
-        horseData.set(new NamespacedKey(BetterHorses.getInstance(), "mount_type"), PersistentDataType.STRING, mountType.getEntityType().name());
+        horseData.set(BetterHorseKeys.BASE_HEALTH, PersistentDataType.DOUBLE,
+                data.getOrDefault(BetterHorseKeys.BASE_HEALTH, PersistentDataType.DOUBLE, health));
+        horseData.set(BetterHorseKeys.BASE_SPEED, PersistentDataType.DOUBLE,
+                data.getOrDefault(BetterHorseKeys.BASE_SPEED, PersistentDataType.DOUBLE, speed));
+        horseData.set(BetterHorseKeys.BASE_JUMP, PersistentDataType.DOUBLE,
+                data.getOrDefault(BetterHorseKeys.BASE_JUMP, PersistentDataType.DOUBLE, jump));
+        horseData.set(BetterHorseKeys.TRAINING_RIDING_UNITS, PersistentDataType.DOUBLE,
+                data.getOrDefault(BetterHorseKeys.TRAINING_RIDING_UNITS, PersistentDataType.DOUBLE, 0.0));
+        horseData.set(BetterHorseKeys.TRAINING_BRUSHING_UNITS, PersistentDataType.DOUBLE,
+                data.getOrDefault(BetterHorseKeys.TRAINING_BRUSHING_UNITS, PersistentDataType.DOUBLE, 0.0));
+        horseData.set(BetterHorseKeys.TRAINING_FEEDING_UNITS, PersistentDataType.DOUBLE,
+                data.getOrDefault(BetterHorseKeys.TRAINING_FEEDING_UNITS, PersistentDataType.DOUBLE, 0.0));
+
+        horseData.set(BetterHorseKeys.OWNER, PersistentDataType.STRING, ownerUUID);
+        horseData.set(BetterHorseKeys.GENDER, PersistentDataType.STRING, gender);
+        horseData.set(BetterHorseKeys.MOUNT_TYPE, PersistentDataType.STRING, mountType.getEntityType().name());
 
         if (trait != null && !trait.isBlank()) {
-            horseData.set(new NamespacedKey(BetterHorses.getInstance(), "trait"), PersistentDataType.STRING, trait);
+            horseData.set(BetterHorseKeys.TRAIT, PersistentDataType.STRING, trait);
         }
 
         if (neutered != null && neutered == (byte) 1) {
-            horseData.set(new NamespacedKey(BetterHorses.getInstance(), "neutered"), PersistentDataType.BYTE, (byte) 1);
+            horseData.set(BetterHorseKeys.NEUTERED, PersistentDataType.BYTE, (byte) 1);
         }
 
         if (cooldown != null) {
-            horseData.set(new NamespacedKey(BetterHorses.getInstance(), "cooldown"), PersistentDataType.LONG, cooldown);
+            horseData.set(BetterHorseKeys.COOLDOWN, PersistentDataType.LONG, cooldown);
         }
 
         if (customName != null && !customName.isBlank()) {

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java
@@ -110,13 +110,14 @@ public final class TrainingManager {
 
     public static List<String> getTrainingLoreLines(AbstractHorse horse) {
         FileConfiguration config = BetterHorses.getInstance().getConfig();
+        FileConfiguration language = BetterHorses.getInstance().getLang().getConfig();
         List<String> lines = new ArrayList<>();
         if (!isTrainingEnabled(config)) return lines;
 
-        lines.add(color(config.getString("training.lore.title", "&6Training")));
-        addCategoryLore(lines, config, horse, "riding", BetterHorseKeys.TRAINING_RIDING_UNITS, "&7Riding Progress: %bar% &b%percent%%");
-        addCategoryLore(lines, config, horse, "brushing", BetterHorseKeys.TRAINING_BRUSHING_UNITS, "&7Brushing Progress: %bar% &b%percent%%");
-        addCategoryLore(lines, config, horse, "feeding", BetterHorseKeys.TRAINING_FEEDING_UNITS, "&7Feeding Progress: %bar% &b%percent%%");
+        lines.add(color(language.getString("training-lore.title", "&6Training")));
+        addCategoryLore(lines, config, language, horse, "riding", BetterHorseKeys.TRAINING_RIDING_UNITS, "&7Riding Progress: %bar% &b%percent%%");
+        addCategoryLore(lines, config, language, horse, "brushing", BetterHorseKeys.TRAINING_BRUSHING_UNITS, "&7Brushing Progress: %bar% &b%percent%%");
+        addCategoryLore(lines, config, language, horse, "feeding", BetterHorseKeys.TRAINING_FEEDING_UNITS, "&7Feeding Progress: %bar% &b%percent%%");
         return lines;
     }
 
@@ -127,22 +128,22 @@ public final class TrainingManager {
         return Math.max(0.0, Math.min(100.0, units / unitsPerPercent));
     }
 
-    private static void addCategoryLore(List<String> lines, FileConfiguration config, AbstractHorse horse, String category, NamespacedKey key, String formatDefault) {
+    private static void addCategoryLore(List<String> lines, FileConfiguration config, FileConfiguration language, AbstractHorse horse, String category, NamespacedKey key, String formatDefault) {
         if (!isCategoryEnabled(config, category)) return;
         PersistentDataContainer data = horse.getPersistentDataContainer();
         double percent = getProgressPercent(config, data, category, key);
         int rounded = (int) Math.round(percent);
-        String bar = progressBar(config, percent);
-        String format = config.getString("training.categories." + category + ".lore-format", formatDefault);
+        String bar = progressBar(config, language, percent);
+        String format = language.getString("training-lore.categories." + category, formatDefault);
         lines.add(color(format.replace("%bar%", bar).replace("%percent%", String.valueOf(rounded))));
     }
 
-    private static String progressBar(FileConfiguration config, double percent) {
+    private static String progressBar(FileConfiguration config, FileConfiguration language, double percent) {
         int length = Math.max(5, config.getInt("training.lore.progress-bar.length", 20));
-        char filledChar = config.getString("training.lore.progress-bar.filled-char", "■").charAt(0);
-        char emptyChar = config.getString("training.lore.progress-bar.empty-char", "■").charAt(0);
-        String filledColor = color(config.getString("training.lore.progress-bar.filled-color", "&b"));
-        String emptyColor = color(config.getString("training.lore.progress-bar.empty-color", "&8"));
+        char filledChar = language.getString("training-lore.progress-bar.filled-char", "■").charAt(0);
+        char emptyChar = language.getString("training-lore.progress-bar.empty-char", "■").charAt(0);
+        String filledColor = color(language.getString("training-lore.progress-bar.filled-color", "&b"));
+        String emptyColor = color(language.getString("training-lore.progress-bar.empty-color", "&8"));
 
         int filled = (int) Math.round((percent / 100.0) * length);
         StringBuilder builder = new StringBuilder();

--- a/BetterHorses/src/main/resources/config.yml
+++ b/BetterHorses/src/main/resources/config.yml
@@ -184,13 +184,8 @@ training:
   enabled: true
 
   lore:
-    title: "&6Training"
     progress-bar:
       length: 20
-      filled-char: "■"
-      empty-char: "■"
-      filled-color: "&b"
-      empty-color: "&8"
 
   categories:
     riding:
@@ -199,7 +194,6 @@ training:
       units-per-percent: 25.0
       # 0.2 means +0.2% speed per 1% progress
       bonus-percent-per-progress-percent: 0.2
-      lore-format: "&7Riding Progress: %bar% &b%percent%%"
 
     brushing:
       enabled: true
@@ -210,7 +204,6 @@ training:
       units-per-percent: 1.0
       # 0.2 means +0.2% jump strength per 1% progress
       bonus-percent-per-progress-percent: 0.2
-      lore-format: "&7Brushing Progress: %bar% &b%percent%%"
 
     feeding:
       enabled: true
@@ -218,7 +211,6 @@ training:
       units-per-percent: 2.0
       # 0.2 means +0.2% max HP per 1% progress
       bonus-percent-per-progress-percent: 0.2
-      lore-format: "&7Feeding Progress: %bar% &b%percent%%"
       food-values:
         WHEAT: 1.0
         APPLE: 1.0

--- a/BetterHorses/src/main/resources/language.yml
+++ b/BetterHorses/src/main/resources/language.yml
@@ -61,3 +61,15 @@ traits:
 
   revenantcurse: "Revenant Curse"
   revenantcurse-message: "The curse has been activated. Attackers will suffer."
+
+training-lore:
+  title: "&6Training"
+  progress-bar:
+    filled-char: "■"
+    empty-char: "■"
+    filled-color: "&b"
+    empty-color: "&8"
+  categories:
+    riding: "&7Riding Progress: %bar% &b%percent%%"
+    brushing: "&7Brushing Progress: %bar% &b%percent%%"
+    feeding: "&7Feeding Progress: %bar% &b%percent%%"


### PR DESCRIPTION
### Motivation
- Ensure horse training progress and base stats survive despawn/respawn by persisting them in the PersistentDataContainer (PDC), and move text-based training settings into the language file so they can be localized.

### Description
- Switch PDC usage to `BetterHorseKeys` constants and write base stats plus `TRAINING_*_UNITS` into the horse item PDC during despawn, and restore them onto the spawned entity PDC during respawn.
- Update `TrainingManager` to read training lore title, category formats and progress-bar characters/colors from `language.yml` under `training-lore.*` while numeric/behavioral settings remain in `config.yml`.
- Remove migrated lore-format and progress-bar text entries from `config.yml` and add the corresponding `training-lore` entries to `language.yml`.
- Adjusted despawn/respawn code paths to use the centralized keys and to include training metadata when creating or spawning horse items.

### Testing
- Ran `./gradlew test` in the `BetterHorses/` module; the run failed due to the environment Java/Gradle incompatibility error `Unsupported class file major version 69` which prevented automated tests from executing.
- No additional automated test runs were performed because the build environment prevented running Gradle tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1c39098a8832bafbaa6ba30bb65cb)