### PR TITLE
Use AttributeResolver for horse jump strength compatibility

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java
@@ -2,6 +2,7 @@ package me.luisgamedev.betterhorses.training;
 
 import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.api.BetterHorseKeys;
+import me.luisgamedev.betterhorses.utils.AttributeResolver;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -32,7 +33,7 @@ public final class TrainingManager {
         PersistentDataContainer data = horse.getPersistentDataContainer();
         saveBaseIfMissing(horse, data, Attribute.GENERIC_MAX_HEALTH, BetterHorseKeys.BASE_HEALTH);
         saveBaseIfMissing(horse, data, Attribute.GENERIC_MOVEMENT_SPEED, BetterHorseKeys.BASE_SPEED);
-        saveBaseIfMissing(horse, data, Attribute.HORSE_JUMP_STRENGTH, BetterHorseKeys.BASE_JUMP);
+        saveBaseIfMissing(horse, data, AttributeResolver.horseJumpStrength(), BetterHorseKeys.BASE_JUMP);
     }
 
     public static void addRidingUnits(AbstractHorse horse, double units) {
@@ -76,7 +77,7 @@ public final class TrainingManager {
 
         double baseHealth = data.getOrDefault(BetterHorseKeys.BASE_HEALTH, PersistentDataType.DOUBLE, readAttribute(horse, Attribute.GENERIC_MAX_HEALTH));
         double baseSpeed = data.getOrDefault(BetterHorseKeys.BASE_SPEED, PersistentDataType.DOUBLE, readAttribute(horse, Attribute.GENERIC_MOVEMENT_SPEED));
-        double baseJump = data.getOrDefault(BetterHorseKeys.BASE_JUMP, PersistentDataType.DOUBLE, readAttribute(horse, Attribute.HORSE_JUMP_STRENGTH));
+        double baseJump = data.getOrDefault(BetterHorseKeys.BASE_JUMP, PersistentDataType.DOUBLE, readAttribute(horse, AttributeResolver.horseJumpStrength()));
 
         double ridingPercent = getProgressPercent(config, data, "riding", BetterHorseKeys.TRAINING_RIDING_UNITS);
         double brushingPercent = getProgressPercent(config, data, "brushing", BetterHorseKeys.TRAINING_BRUSHING_UNITS);
@@ -91,7 +92,7 @@ public final class TrainingManager {
         double boostedHealth = baseHealth * (1.0 + (feedingPercent * healthBonusPerPercent / 100.0));
 
         setAttribute(horse, Attribute.GENERIC_MOVEMENT_SPEED, boostedSpeed);
-        setAttribute(horse, Attribute.HORSE_JUMP_STRENGTH, boostedJump);
+        setAttribute(horse, AttributeResolver.horseJumpStrength(), boostedJump);
 
         double oldHealth = readAttribute(horse, Attribute.GENERIC_MAX_HEALTH);
         setAttribute(horse, Attribute.GENERIC_MAX_HEALTH, boostedHealth);

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/AttributeResolver.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/AttributeResolver.java
@@ -31,6 +31,16 @@ public final class AttributeResolver {
         return resolveWithFallback(normalized, "GENERIC_" + normalized);
     }
 
+    /**
+     * Resolves horse jump strength across versions where it was renamed from
+     * {@code HORSE_JUMP_STRENGTH} to {@code JUMP_STRENGTH}.
+     *
+     * @return the matching jump strength {@link Attribute}
+     */
+    public static Attribute horseJumpStrength() {
+        return resolveWithFallback("HORSE_JUMP_STRENGTH", "JUMP_STRENGTH");
+    }
+
     private static Attribute resolveWithFallback(String primary, String fallback) {
         try {
             return Attribute.valueOf(primary);


### PR DESCRIPTION
### Motivation
- Ensure the plugin resolves the horse jump attribute across Minecraft/Bukkit versions where the enum name changed and avoid unresolved-symbol errors for `HORSE_JUMP_STRENGTH`.

### Description
- Added `AttributeResolver.horseJumpStrength()` which resolves between `HORSE_JUMP_STRENGTH` and `JUMP_STRENGTH` with fallback logic.
- Replaced direct uses of `Attribute.HORSE_JUMP_STRENGTH` in `TrainingManager` with `AttributeResolver.horseJumpStrength()` and added the resolver import.
- Affected files: `BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/AttributeResolver.java` and `BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java`.

### Testing
- Ran `cd BetterHorses && ./gradlew build -x test`, which failed in this environment due to a Java/Gradle compatibility issue (`Unsupported class file major version 69`), so the environment build did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1c6156dc8832b90e68674260e64fa)