### PR TITLE
Initialize missing training progress data to zero

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RightClickListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RightClickListener.java
@@ -56,6 +56,8 @@ public class RightClickListener implements Listener {
 
         ItemMeta meta = item.getItemMeta();
         PersistentDataContainer data = meta.getPersistentDataContainer();
+        TrainingManager.ensureTrainingData(data);
+        item.setItemMeta(meta);
 
         Double health = data.get(new NamespacedKey(BetterHorses.getInstance(), "health"), PersistentDataType.DOUBLE);
         Double currentHealth = data.get(new NamespacedKey(BetterHorses.getInstance(), "current_health"), PersistentDataType.DOUBLE);

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java
@@ -42,6 +42,7 @@ public final class TrainingManager {
         if (!isTrainingEnabled(config) || !isCategoryEnabled(config, "riding")) return;
 
         PersistentDataContainer data = horse.getPersistentDataContainer();
+        ensureTrainingData(data);
         double current = data.getOrDefault(BetterHorseKeys.TRAINING_RIDING_UNITS, PersistentDataType.DOUBLE, 0.0);
         data.set(BetterHorseKeys.TRAINING_RIDING_UNITS, PersistentDataType.DOUBLE, current + units);
         recalculateAndApplyBonuses(horse);
@@ -53,6 +54,7 @@ public final class TrainingManager {
         if (!isTrainingEnabled(config) || !isCategoryEnabled(config, "brushing")) return;
 
         PersistentDataContainer data = horse.getPersistentDataContainer();
+        ensureTrainingData(data);
         double current = data.getOrDefault(BetterHorseKeys.TRAINING_BRUSHING_UNITS, PersistentDataType.DOUBLE, 0.0);
         data.set(BetterHorseKeys.TRAINING_BRUSHING_UNITS, PersistentDataType.DOUBLE, current + units);
         recalculateAndApplyBonuses(horse);
@@ -64,6 +66,7 @@ public final class TrainingManager {
         if (!isTrainingEnabled(config) || !isCategoryEnabled(config, "feeding")) return;
 
         PersistentDataContainer data = horse.getPersistentDataContainer();
+        ensureTrainingData(data);
         double current = data.getOrDefault(BetterHorseKeys.TRAINING_FEEDING_UNITS, PersistentDataType.DOUBLE, 0.0);
         data.set(BetterHorseKeys.TRAINING_FEEDING_UNITS, PersistentDataType.DOUBLE, current + units);
         recalculateAndApplyBonuses(horse);
@@ -73,6 +76,7 @@ public final class TrainingManager {
         FileConfiguration config = BetterHorses.getInstance().getConfig();
         PersistentDataContainer data = horse.getPersistentDataContainer();
 
+        ensureTrainingData(data);
         ensureBaseStats(horse);
 
         double baseHealth = data.getOrDefault(BetterHorseKeys.BASE_HEALTH, PersistentDataType.DOUBLE, readAttribute(horse, Attribute.GENERIC_MAX_HEALTH));
@@ -115,6 +119,8 @@ public final class TrainingManager {
         List<String> lines = new ArrayList<>();
         if (!isTrainingEnabled(config)) return lines;
 
+        ensureTrainingData(horse.getPersistentDataContainer());
+
         lines.add(color(language.getString("training-lore.title", "&6Training")));
         addCategoryLore(lines, config, language, horse, "riding", BetterHorseKeys.TRAINING_RIDING_UNITS, "&7Riding Progress: %bar% &b%percent%%");
         addCategoryLore(lines, config, language, horse, "brushing", BetterHorseKeys.TRAINING_BRUSHING_UNITS, "&7Brushing Progress: %bar% &b%percent%%");
@@ -124,9 +130,22 @@ public final class TrainingManager {
 
     public static double getProgressPercent(FileConfiguration config, PersistentDataContainer data, String category, NamespacedKey unitsKey) {
         if (!isTrainingEnabled(config) || !isCategoryEnabled(config, category)) return 0.0;
+        ensureTrainingData(data);
         double units = data.getOrDefault(unitsKey, PersistentDataType.DOUBLE, 0.0);
         double unitsPerPercent = Math.max(0.0001, config.getDouble("training.categories." + category + ".units-per-percent", 10.0));
         return Math.max(0.0, Math.min(100.0, units / unitsPerPercent));
+    }
+
+    public static void ensureTrainingData(PersistentDataContainer data) {
+        ensureTrainingUnits(data, BetterHorseKeys.TRAINING_RIDING_UNITS);
+        ensureTrainingUnits(data, BetterHorseKeys.TRAINING_BRUSHING_UNITS);
+        ensureTrainingUnits(data, BetterHorseKeys.TRAINING_FEEDING_UNITS);
+    }
+
+    private static void ensureTrainingUnits(PersistentDataContainer data, NamespacedKey unitsKey) {
+        if (!data.has(unitsKey, PersistentDataType.DOUBLE)) {
+            data.set(unitsKey, PersistentDataType.DOUBLE, 0.0);
+        }
     }
 
     private static void addCategoryLore(List<String> lines, FileConfiguration config, FileConfiguration language, AbstractHorse horse, String category, NamespacedKey key, String formatDefault) {


### PR DESCRIPTION
### Motivation
- Ensure horses and horse items without legacy training metadata automatically receive zero progress so training calculations and lore rendering behave predictably.
- No session skills were used; this is a focused code change applied directly to the plugin source.

### Description
- Added `TrainingManager.ensureTrainingData(PersistentDataContainer)` and helper `ensureTrainingUnits(...)` to create missing `TRAINING_*_UNITS` keys with `0.0`.
- Invoked the initializer from training update paths (`addRidingUnits`, `addBrushingUnits`, `addFeedingUnits`), bonus recalculation (`recalculateAndApplyBonuses`), lore generation (`getTrainingLoreLines`) and percent calculation (`getProgressPercent`) to normalize horse PDCs before use.
- Initialized training keys on item metadata during right-click spawn handling by calling `TrainingManager.ensureTrainingData(data)` and writing the meta back with `item.setItemMeta(meta)` so items also get `0.0` defaults.

### Testing
- Attempted to run `./gradlew build` in the project root, but the build failed in this environment with `Unsupported class file major version 69` due to local Java/Gradle compatibility and not because of plugin logic.
- Confirmed source changes were staged and committed (`Initialize missing training progress data to zero`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1d71d4944832b98e06e97d18132a0)