### PR TITLE
Show training lore on horse items and when creating with /horsecreate

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
@@ -5,6 +5,7 @@ import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.api.events.BetterHorseDespawnEvent;
 import me.luisgamedev.betterhorses.api.events.BetterHorseSpawnEvent;
 import me.luisgamedev.betterhorses.language.LanguageManager;
+import me.luisgamedev.betterhorses.training.TrainingManager;
 import me.luisgamedev.betterhorses.utils.SupportedMountType;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -72,6 +73,9 @@ public class BetterHorsesAPI {
         data.set(BetterHorseKeys.COLOR, PersistentDataType.STRING, Horse.Color.CREAMY.name());
         data.set(BetterHorseKeys.GROWTH_STAGE, PersistentDataType.INTEGER, growth);
         data.set(BetterHorseKeys.MOUNT_TYPE, PersistentDataType.STRING, targetMountType.getEntityType().name());
+        TrainingManager.ensureTrainingData(data);
+
+        lore.addAll(TrainingManager.getTrainingLoreLines(data));
 
         FileConfiguration config = plugin.getConfig();
         if (config.getBoolean("traits.enabled")) {

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java
@@ -114,17 +114,21 @@ public final class TrainingManager {
     }
 
     public static List<String> getTrainingLoreLines(AbstractHorse horse) {
+        return getTrainingLoreLines(horse.getPersistentDataContainer());
+    }
+
+    public static List<String> getTrainingLoreLines(PersistentDataContainer data) {
         FileConfiguration config = BetterHorses.getInstance().getConfig();
         FileConfiguration language = BetterHorses.getInstance().getLang().getConfig();
         List<String> lines = new ArrayList<>();
         if (!isTrainingEnabled(config)) return lines;
 
-        ensureTrainingData(horse.getPersistentDataContainer());
+        ensureTrainingData(data);
 
         lines.add(color(language.getString("training-lore.title", "&6Training")));
-        addCategoryLore(lines, config, language, horse, "riding", BetterHorseKeys.TRAINING_RIDING_UNITS, "&7Riding Progress: %bar% &b%percent%%");
-        addCategoryLore(lines, config, language, horse, "brushing", BetterHorseKeys.TRAINING_BRUSHING_UNITS, "&7Brushing Progress: %bar% &b%percent%%");
-        addCategoryLore(lines, config, language, horse, "feeding", BetterHorseKeys.TRAINING_FEEDING_UNITS, "&7Feeding Progress: %bar% &b%percent%%");
+        addCategoryLore(lines, config, language, data, "riding", BetterHorseKeys.TRAINING_RIDING_UNITS, "&7Riding Progress: %bar% &b%percent%%");
+        addCategoryLore(lines, config, language, data, "brushing", BetterHorseKeys.TRAINING_BRUSHING_UNITS, "&7Brushing Progress: %bar% &b%percent%%");
+        addCategoryLore(lines, config, language, data, "feeding", BetterHorseKeys.TRAINING_FEEDING_UNITS, "&7Feeding Progress: %bar% &b%percent%%");
         return lines;
     }
 
@@ -148,9 +152,8 @@ public final class TrainingManager {
         }
     }
 
-    private static void addCategoryLore(List<String> lines, FileConfiguration config, FileConfiguration language, AbstractHorse horse, String category, NamespacedKey key, String formatDefault) {
+    private static void addCategoryLore(List<String> lines, FileConfiguration config, FileConfiguration language, PersistentDataContainer data, String category, NamespacedKey key, String formatDefault) {
         if (!isCategoryEnabled(config, category)) return;
-        PersistentDataContainer data = horse.getPersistentDataContainer();
         double percent = getProgressPercent(config, data, category, key);
         int rounded = (int) Math.round(percent);
         String bar = progressBar(config, language, percent);


### PR DESCRIPTION
### Motivation
- Training progress lines were only generated for live horse entities (e.g. on despawn) and were missing from horse items created via the API (such as `/horsecreate`), so items did not show training when the feature was enabled in config.

### Description
- Added an overload `TrainingManager.getTrainingLoreLines(PersistentDataContainer)` and refactored category rendering to accept a `PersistentDataContainer` so lore can be built from item metadata as well as live horses.
- Updated `BetterHorsesAPI.createHorseItem(...)` to call `TrainingManager.ensureTrainingData(data)` and append `TrainingManager.getTrainingLoreLines(data)` to the new item lore when training is enabled.
- Adjusted `addCategoryLore(...)` to accept `PersistentDataContainer` and reuse the same progress formatting logic for items and entities.
- Changes touch `BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java` and `BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java`.

### Testing
- Ran `./gradlew build` to validate compilation, which failed in this environment due to a Gradle/JDK compatibility issue (`Unsupported class file major version 69`) unrelated to the logic changes.
- No additional automated tests are present in the project; logic changes are small and limited to lore generation and PDC initialization, and the build error prevented a full verification run in CI here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1daa166b8832ba3c0b926fbe320d9)