### PR TITLE
Ensure training lore is present on created and despawned horse items

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
@@ -75,7 +75,7 @@ public class BetterHorsesAPI {
         data.set(BetterHorseKeys.MOUNT_TYPE, PersistentDataType.STRING, targetMountType.getEntityType().name());
         TrainingManager.ensureTrainingData(data);
 
-        lore.addAll(TrainingManager.getTrainingLoreLines(data));
+        TrainingManager.ensureTrainingLorePresent(lore, data);
 
         FileConfiguration config = plugin.getConfig();
         if (config.getBoolean("traits.enabled")) {

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/DespawnCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/DespawnCommand.java
@@ -132,7 +132,7 @@ public class DespawnCommand {
         lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-speed", "%value%", String.format("%.4f", speed)));
         lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-jump", "%value%", String.format("%.4f", jump)));
         lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-growth", "%value%", String.format("%d", growthStage)));
-        lore.addAll(TrainingManager.getTrainingLoreLines(horse));
+        TrainingManager.ensureTrainingLorePresent(lore, data);
 
         if (trait != null) {
             lore.add(ChatColor.GOLD + lang.getFormattedRaw("messages.trait-line", "%trait%", formatTraitName(trait)));

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java
@@ -133,6 +133,24 @@ public final class TrainingManager {
         return lines;
     }
 
+    public static void ensureTrainingLorePresent(List<String> lore, PersistentDataContainer data) {
+        FileConfiguration config = BetterHorses.getInstance().getConfig();
+        if (!isTrainingEnabled(config)) return;
+
+        List<String> trainingLines = getTrainingLoreLines(data);
+        if (trainingLines.isEmpty()) return;
+
+        String titleLine = trainingLines.size() > 1 ? trainingLines.get(1) : trainingLines.get(0);
+        String normalizedTitle = ChatColor.stripColor(titleLine);
+        boolean hasTrainingTitle = lore.stream()
+                .map(ChatColor::stripColor)
+                .anyMatch(existing -> existing != null && existing.equalsIgnoreCase(normalizedTitle));
+
+        if (!hasTrainingTitle) {
+            lore.addAll(trainingLines);
+        }
+    }
+
     public static double getProgressPercent(FileConfiguration config, PersistentDataContainer data, String category, NamespacedKey unitsKey) {
         if (!isTrainingEnabled(config) || !isCategoryEnabled(config, category)) return 0.0;
         ensureTrainingData(data);


### PR DESCRIPTION
### Motivation
- Fix a bug where horse items created via `/horsecreate` or by despawning a mount could be missing the training lore block even when training is enabled in the config.
- Ensure training lore is always present on horse items (but avoid duplicating the block if it already exists).

### Description
- Added `TrainingManager.ensureTrainingLorePresent(List<String> lore, PersistentDataContainer data)` which appends the training lore lines only when `training.enabled` is true and the training lore block is not already present.
- Replaced `lore.addAll(TrainingManager.getTrainingLoreLines(...))` with `TrainingManager.ensureTrainingLorePresent(lore, data)` in `BetterHorsesAPI.createHorseItem` so newly created items include training lore.
- Replaced `lore.addAll(TrainingManager.getTrainingLoreLines(horse))` with `TrainingManager.ensureTrainingLorePresent(lore, data)` in `DespawnCommand.despawnHorseToItem` so despawned items consistently include training lore.
- Preserved existing training data initialization by continuing to call `TrainingManager.ensureTrainingData(...)` before ensuring lore is present.

### Testing
- Attempted to run `cd BetterHorses && ./gradlew test --no-daemon`, but the build failed in this environment with `Unsupported class file major version 69` (toolchain/JDK mismatch), so automated tests could not be executed here.
- Changes were applied and committed locally in the repository; no automated test results are available due to the environment toolchain issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1dca764d4832bb64852df5dfa39af)