### PR TITLE
Add persistent training cooldown for feeding (matches brushing)

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorseKeys.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorseKeys.java
@@ -33,6 +33,7 @@ public final class BetterHorseKeys {
     public static final NamespacedKey TRAINING_BRUSHING_UNITS = key("training_brushing_units");
     public static final NamespacedKey TRAINING_FEEDING_UNITS = key("training_feeding_units");
     public static final NamespacedKey TRAINING_BRUSH_COOLDOWN = key("training_brush_cooldown");
+    public static final NamespacedKey TRAINING_FEED_COOLDOWN = key("training_feed_cooldown");
 
     private static NamespacedKey key(String key) {
         return new NamespacedKey(BetterHorses.getInstance(), key);

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/DespawnCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/DespawnCommand.java
@@ -156,6 +156,8 @@ public class DespawnCommand {
         itemData.set(BetterHorseKeys.TRAINING_RIDING_UNITS, PersistentDataType.DOUBLE, data.getOrDefault(BetterHorseKeys.TRAINING_RIDING_UNITS, PersistentDataType.DOUBLE, 0.0));
         itemData.set(BetterHorseKeys.TRAINING_BRUSHING_UNITS, PersistentDataType.DOUBLE, data.getOrDefault(BetterHorseKeys.TRAINING_BRUSHING_UNITS, PersistentDataType.DOUBLE, 0.0));
         itemData.set(BetterHorseKeys.TRAINING_FEEDING_UNITS, PersistentDataType.DOUBLE, data.getOrDefault(BetterHorseKeys.TRAINING_FEEDING_UNITS, PersistentDataType.DOUBLE, 0.0));
+        itemData.set(BetterHorseKeys.TRAINING_BRUSH_COOLDOWN, PersistentDataType.LONG, data.getOrDefault(BetterHorseKeys.TRAINING_BRUSH_COOLDOWN, PersistentDataType.LONG, 0L));
+        itemData.set(BetterHorseKeys.TRAINING_FEED_COOLDOWN, PersistentDataType.LONG, data.getOrDefault(BetterHorseKeys.TRAINING_FEED_COOLDOWN, PersistentDataType.LONG, 0L));
         itemData.set(BetterHorseKeys.OWNER, PersistentDataType.STRING, player.getUniqueId().toString());
         itemData.set(BetterHorseKeys.STYLE, PersistentDataType.STRING, style.name());
         itemData.set(BetterHorseKeys.COLOR, PersistentDataType.STRING, color.name());

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/RespawnCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/RespawnCommand.java
@@ -57,6 +57,8 @@ public class RespawnCommand {
         Byte neutered = data.get(BetterHorseKeys.NEUTERED, PersistentDataType.BYTE);
         Integer storedStage = data.get(BetterHorseKeys.GROWTH_STAGE, PersistentDataType.INTEGER);
         String mountTypeName = data.get(BetterHorseKeys.MOUNT_TYPE, PersistentDataType.STRING);
+        long brushTrainingCooldown = data.getOrDefault(BetterHorseKeys.TRAINING_BRUSH_COOLDOWN, PersistentDataType.LONG, 0L);
+        long feedTrainingCooldown = data.getOrDefault(BetterHorseKeys.TRAINING_FEED_COOLDOWN, PersistentDataType.LONG, 0L);
         Long cooldown = data.has(BetterHorseKeys.COOLDOWN, PersistentDataType.LONG)
                 ? data.get(BetterHorseKeys.COOLDOWN, PersistentDataType.LONG)
                 : null;
@@ -136,6 +138,8 @@ public class RespawnCommand {
                 data.getOrDefault(BetterHorseKeys.TRAINING_BRUSHING_UNITS, PersistentDataType.DOUBLE, 0.0));
         horseData.set(BetterHorseKeys.TRAINING_FEEDING_UNITS, PersistentDataType.DOUBLE,
                 data.getOrDefault(BetterHorseKeys.TRAINING_FEEDING_UNITS, PersistentDataType.DOUBLE, 0.0));
+        horseData.set(BetterHorseKeys.TRAINING_BRUSH_COOLDOWN, PersistentDataType.LONG, brushTrainingCooldown);
+        horseData.set(BetterHorseKeys.TRAINING_FEED_COOLDOWN, PersistentDataType.LONG, feedTrainingCooldown);
 
         horseData.set(BetterHorseKeys.OWNER, PersistentDataType.STRING, ownerUUID);
         horseData.set(BetterHorseKeys.GENDER, PersistentDataType.STRING, gender);

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseFeedListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseFeedListener.java
@@ -1,9 +1,9 @@
 package me.luisgamedev.betterhorses.listeners;
 
 import me.luisgamedev.betterhorses.BetterHorses;
+import me.luisgamedev.betterhorses.api.BetterHorseKeys;
 import me.luisgamedev.betterhorses.training.TrainingManager;
 import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
 import org.bukkit.Particle;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Horse;
@@ -15,11 +15,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 
-
 public class HorseFeedListener implements Listener {
-
-    private final NamespacedKey cooldownKey = new NamespacedKey(BetterHorses.getInstance(), "cooldown");
-    private final NamespacedKey genderKey   = new NamespacedKey(BetterHorses.getInstance(), "gender");
 
     @EventHandler
     public void onHorseFeed(PlayerInteractEntityEvent event) {
@@ -43,7 +39,6 @@ public class HorseFeedListener implements Listener {
         if (!isFood) return;
 
         final double feedingTrainingValue = TrainingManager.getFoodTrainingValue(type);
-
         final FileConfiguration config = BetterHorses.getInstance().getConfig();
 
         if (!horse.isAdult() && config.getBoolean("horse-growth-settings.enabled", false)) {
@@ -53,47 +48,60 @@ public class HorseFeedListener implements Listener {
 
         if (!horse.isTamed()) return;
 
+        final long now = System.currentTimeMillis();
+        final PersistentDataContainer data = horse.getPersistentDataContainer();
+
         final long cooldownSeconds = config.getLong("settings.breeding-cooldown", 0L);
-        if (cooldownSeconds <= 0L) {
-            if (feedingTrainingValue > 0) {
-                TrainingManager.addFeedingUnits(horse, feedingTrainingValue);
+        if (cooldownSeconds > 0L) {
+            final long cooldownMillis = cooldownSeconds * 1000L;
+
+            if (config.getBoolean("settings.male-ignore-cooldown", false)) {
+                final String gender = data.getOrDefault(BetterHorseKeys.GENDER, PersistentDataType.STRING, "UNKNOWN");
+                if ("male".equalsIgnoreCase(gender)) {
+                    horse.setAge(0);
+                    tryAddFeedingTraining(horse, data, config, feedingTrainingValue, now);
+                    return;
+                }
             }
+
+            final long lastBreed = data.getOrDefault(BetterHorseKeys.COOLDOWN, PersistentDataType.LONG, 0L);
+            horse.setAge(0);
+
+            if (lastBreed > 0L) {
+                final long elapsed = now - lastBreed;
+                final long remaining = cooldownMillis - elapsed;
+
+                if (remaining > 0L) {
+                    event.setCancelled(true);
+                } else {
+                    data.remove(BetterHorseKeys.COOLDOWN);
+                }
+            }
+        }
+
+        if (!event.isCancelled()) {
+            tryAddFeedingTraining(horse, data, config, feedingTrainingValue, now);
+        }
+    }
+
+    private void tryAddFeedingTraining(Horse horse, PersistentDataContainer data, FileConfiguration config, double feedingTrainingValue, long now) {
+        if (feedingTrainingValue <= 0) {
             return;
         }
 
-        final long cooldownMillis = cooldownSeconds * 1000L;
-        final long now = System.currentTimeMillis();
+        if (TrainingManager.isTrainingEnabled(config) && TrainingManager.isCategoryEnabled(config, "feeding")) {
+            final long trainingCooldownMillis = Math.max(0L,
+                    config.getLong("training.categories.feeding.cooldown-seconds", 0L) * 1000L);
+            final long lastFeedTraining = data.getOrDefault(BetterHorseKeys.TRAINING_FEED_COOLDOWN, PersistentDataType.LONG, 0L);
 
-        final PersistentDataContainer data = horse.getPersistentDataContainer();
-        if (config.getBoolean("settings.male-ignore-cooldown", false)) {
-            final String gender = data.getOrDefault(genderKey, PersistentDataType.STRING, "UNKNOWN");
-            if ("male".equalsIgnoreCase(gender)) {
-                horse.setAge(0);
-                if (feedingTrainingValue > 0) {
-                    TrainingManager.addFeedingUnits(horse, feedingTrainingValue);
-                }
+            if (trainingCooldownMillis > 0L && now - lastFeedTraining < trainingCooldownMillis) {
                 return;
             }
+
+            data.set(BetterHorseKeys.TRAINING_FEED_COOLDOWN, PersistentDataType.LONG, now);
         }
 
-        final long lastBreed = data.getOrDefault(cooldownKey, PersistentDataType.LONG, 0L);
-
-        horse.setAge(0);
-
-        if (lastBreed > 0L) {
-            final long elapsed = now - lastBreed;
-            final long remaining = cooldownMillis - elapsed;
-
-            if (remaining > 0L) {
-                event.setCancelled(true);
-            } else {
-                data.remove(cooldownKey);
-            }
-        }
-
-        if (!event.isCancelled() && feedingTrainingValue > 0) {
-            TrainingManager.addFeedingUnits(horse, feedingTrainingValue);
-            horse.getWorld().spawnParticle(Particle.COMPOSTER, horse.getLocation().add(0, 1, 0), 5);
-        }
+        TrainingManager.addFeedingUnits(horse, feedingTrainingValue);
+        horse.getWorld().spawnParticle(Particle.COMPOSTER, horse.getLocation().add(0, 1, 0), 5);
     }
 }

--- a/BetterHorses/src/main/resources/config.yml
+++ b/BetterHorses/src/main/resources/config.yml
@@ -207,6 +207,7 @@ training:
 
     feeding:
       enabled: true
+      cooldown-seconds: 180
       # 1% progress = this much total food value
       units-per-percent: 2.0
       # 0.2 means +0.2% max HP per 1% progress


### PR DESCRIPTION
### Motivation

- Prevent feeding training from being reset when a horse is despawned and respawned by making feeding cooldown persistent like brushing. 
- Add a dedicated training cooldown gate for the `feeding` category similar to the existing `brushing` cooldown. 
- Preserve training cooldown timestamps across the horse item lifecycle so cooldowns survive spawn/despawn operations. 

### Description

- Added a new namespaced key `TRAINING_FEED_COOLDOWN` in `BetterHorseKeys.java` to store feeding training timestamps. 
- Implemented training cooldown enforcement in `HorseFeedListener.java` using `training.categories.feeding.cooldown-seconds` and set `TRAINING_FEED_COOLDOWN` when feeding training units are awarded; also refactored the flow into `tryAddFeedingTraining`. 
- Persisted both `TRAINING_BRUSH_COOLDOWN` and `TRAINING_FEED_COOLDOWN` into the horse item on despawn and restored them to the horse on respawn in `DespawnCommand.java` and `RespawnCommand.java`. 
- Added a default `training.categories.feeding.cooldown-seconds: 180` entry to `config.yml` to mirror brushing. 

### Testing

- Executed `./gradlew test` in the project, which could not complete due to an environment JDK/Gradle mismatch and failed with `Unsupported class file major version 69`, so unit tests were not run to completion.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2b024a21c832b9305a78bf1defa2b)