### PR TITLE
Preserve training cooldowns when respawning horses

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RightClickListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RightClickListener.java
@@ -69,6 +69,8 @@ public class RightClickListener implements Listener {
         Double ridingUnits = data.get(BetterHorseKeys.TRAINING_RIDING_UNITS, PersistentDataType.DOUBLE);
         Double brushingUnits = data.get(BetterHorseKeys.TRAINING_BRUSHING_UNITS, PersistentDataType.DOUBLE);
         Double feedingUnits = data.get(BetterHorseKeys.TRAINING_FEEDING_UNITS, PersistentDataType.DOUBLE);
+        long brushTrainingCooldown = data.getOrDefault(BetterHorseKeys.TRAINING_BRUSH_COOLDOWN, PersistentDataType.LONG, 0L);
+        long feedTrainingCooldown = data.getOrDefault(BetterHorseKeys.TRAINING_FEED_COOLDOWN, PersistentDataType.LONG, 0L);
         String gender = data.get(new NamespacedKey(BetterHorses.getInstance(), "gender"), PersistentDataType.STRING);
         String ownerUUID = player.getUniqueId().toString();
         String styleStr = data.get(new NamespacedKey(BetterHorses.getInstance(), "style"), PersistentDataType.STRING);
@@ -151,6 +153,8 @@ public class RightClickListener implements Listener {
         horseData.set(BetterHorseKeys.TRAINING_RIDING_UNITS, PersistentDataType.DOUBLE, ridingUnits != null ? ridingUnits : 0.0);
         horseData.set(BetterHorseKeys.TRAINING_BRUSHING_UNITS, PersistentDataType.DOUBLE, brushingUnits != null ? brushingUnits : 0.0);
         horseData.set(BetterHorseKeys.TRAINING_FEEDING_UNITS, PersistentDataType.DOUBLE, feedingUnits != null ? feedingUnits : 0.0);
+        horseData.set(BetterHorseKeys.TRAINING_BRUSH_COOLDOWN, PersistentDataType.LONG, brushTrainingCooldown);
+        horseData.set(BetterHorseKeys.TRAINING_FEED_COOLDOWN, PersistentDataType.LONG, feedTrainingCooldown);
 
         if (trait != null && !trait.isBlank()) {
             horseData.set(new NamespacedKey(BetterHorses.getInstance(), "trait"), PersistentDataType.STRING, trait);


### PR DESCRIPTION
### Motivation
- Fix a bug that allowed brushing and feeding training cooldowns to be bypassed by despawning a horse item and respawning it via right-click. 
- Ensure training cooldown timestamps persisted on horse items are restored back onto the spawned entity so cooldown state is preserved. 

### Description
- Restore persisted cooldowns in the right-click item-spawn path by reading `TRAINING_BRUSH_COOLDOWN` and `TRAINING_FEED_COOLDOWN` from the item `PersistentDataContainer` in `RightClickListener`. 
- Write those cooldown timestamps into the spawned horse's `PersistentDataContainer` so brushing/feeding training cooldown checks respect the original timestamps. 
- Change is implemented in `BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RightClickListener.java` and mirrors the behavior already present in the item `RespawnCommand` path.

### Testing
- Ran the project's test task with `./gradlew test` in the `BetterHorses` module. 
- The test run failed in this environment due to a Gradle/Java compatibility error: `Unsupported class file major version 69`, so unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2bf4eca64832b864913b6b7d44f96)