### PR TITLE
Add configurable per-trait particles with fallback and warnings

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/tasks/TraitParticleTask.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/tasks/TraitParticleTask.java
@@ -1,6 +1,7 @@
 package me.luisgamedev.betterhorses.tasks;
 
 import me.luisgamedev.betterhorses.BetterHorses;
+import me.luisgamedev.betterhorses.traits.TraitParticleResolver;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Particle;
@@ -29,34 +30,34 @@ public class TraitParticleTask implements Runnable {
 
                 switch (trait.toLowerCase()) {
                     case "skyburst":
-                        spawn(horse, Particle.CLOUD, 1, 0.3, 0.1, 0.3);
+                        spawn(horse, TraitParticleResolver.getTraitParticle("skyburst", Particle.CLOUD), 1, 0.3, 0.1, 0.3);
                         break;
                     case "hellmare":
-                        spawn(horse, Particle.FLAME, 4, 0.3, 0.1, 0.3);
+                        spawn(horse, TraitParticleResolver.getTraitParticle("hellmare", Particle.FLAME), 4, 0.3, 0.1, 0.3);
                         break;
                     case "ghosthorse":
-                        spawn(horse, Particle.SMOKE, 4, 0.25, 0.2, 0.25);
+                        spawn(horse, TraitParticleResolver.getTraitParticle("ghosthorse", Particle.SMOKE), 4, 0.25, 0.2, 0.25);
                         break;
                     case "dashboost":
-                        spawn(horse, Particle.SWEEP_ATTACK, 2, 0.2, 0.1, 0.2);
+                        spawn(horse, TraitParticleResolver.getTraitParticle("dashboost", Particle.SWEEP_ATTACK), 2, 0.2, 0.1, 0.2);
                         break;
                     case "revenantcurse":
-                        spawn(horse, Particle.SOUL, 3, 0.25, 0.3, 0.25);
+                        spawn(horse, TraitParticleResolver.getTraitParticle("revenantcurse", Particle.SOUL), 3, 0.25, 0.3, 0.25);
                         break;
                     case "frosthooves":
-                        spawn(horse, Particle.SNOWFLAKE, 3, 0.3, 0.1, 0.3);
+                        spawn(horse, TraitParticleResolver.getTraitParticle("frosthooves", Particle.SNOWFLAKE), 3, 0.3, 0.1, 0.3);
                         break;
                     case "kickback":
-                        spawn(horse, Particle.CRIT, 2, 0.25, 0.2, 0.25);
+                        spawn(horse, TraitParticleResolver.getTraitParticle("kickback", Particle.CRIT), 2, 0.25, 0.2, 0.25);
                         break;
                     case "featherhooves":
-                        spawn(horse, Particle.CLOUD, 2, 0.2, 0.3, 0.2);
+                        spawn(horse, TraitParticleResolver.getTraitParticle("featherhooves", Particle.CLOUD), 2, 0.2, 0.3, 0.2);
                         break;
                     case "fireheart":
-                        spawn(horse, Particle.LAVA, 2, 0.2, 0.1, 0.2);
+                        spawn(horse, TraitParticleResolver.getTraitParticle("fireheart", Particle.LAVA), 2, 0.2, 0.1, 0.2);
                         break;
                     case "heavenhooves":
-                        spawn(horse, Particle.GLOW, 2, 0.2, 0.3, 0.2);
+                        spawn(horse, TraitParticleResolver.getTraitParticle("heavenhooves", Particle.GLOW), 2, 0.2, 0.3, 0.2);
                 }
             }
         }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/traits/TraitParticleResolver.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/traits/TraitParticleResolver.java
@@ -1,0 +1,38 @@
+package me.luisgamedev.betterhorses.traits;
+
+import me.luisgamedev.betterhorses.BetterHorses;
+import org.bukkit.Particle;
+
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+public final class TraitParticleResolver {
+
+    private static final Set<String> warnedInvalidParticles = new HashSet<>();
+
+    private TraitParticleResolver() {
+    }
+
+    public static Particle getTraitParticle(String traitKey, Particle fallback) {
+        BetterHorses plugin = BetterHorses.getInstance();
+        String path = "traits." + traitKey + ".particle";
+        String configured = plugin.getConfig().getString(path, fallback.name());
+
+        if (configured == null || configured.isBlank()) {
+            return fallback;
+        }
+
+        String normalized = configured.trim().toUpperCase(Locale.ROOT);
+        try {
+            return Particle.valueOf(normalized);
+        } catch (IllegalArgumentException ignored) {
+            String warningKey = traitKey.toLowerCase(Locale.ROOT) + ":" + normalized;
+            if (warnedInvalidParticles.add(warningKey)) {
+                plugin.getLogger().warning("Invalid particle '" + configured + "' at " + path
+                        + ". Falling back to " + fallback.name() + ".");
+            }
+            return fallback;
+        }
+    }
+}

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/traits/TraitRegistry.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/traits/TraitRegistry.java
@@ -63,7 +63,8 @@ public class TraitRegistry {
                 }
                 Location center = horse.getLocation().clone().subtract(0, 1, 0);
                 World world = center.getWorld();
-                world.spawnParticle(Particle.FLAME, horse.getLocation(), 10, 0.4, 0.2, 0.4, 0.01);
+                Particle hellmareParticle = TraitParticleResolver.getTraitParticle("hellmare", Particle.FLAME);
+                world.spawnParticle(hellmareParticle, horse.getLocation(), 10, 0.4, 0.2, 0.4, 0.01);
 
                 for (int dx = -radius; dx <= radius; dx++) {
                     for (int dz = -radius; dz <= radius; dz++) {
@@ -121,7 +122,7 @@ public class TraitRegistry {
 
         if (config.getBoolean("traits.heavenhooves.particles")) {
             horse.getWorld().spawnParticle(
-                    Particle.CLOUD,
+                    TraitParticleResolver.getTraitParticle("heavenhooves", Particle.CLOUD),
                     horse.getLocation().add(0, 1.5, 0),
                     8,
                     0.3, 0.2, 0.3,
@@ -226,7 +227,8 @@ public class TraitRegistry {
         if (!config.getBoolean("traits.skyburst.enabled")) return;
 
         double radius = config.getDouble("traits.skyburst.radius", 3.0);
-        player.getWorld().spawnParticle(Particle.CLOUD, horse.getLocation(), 20, 0.5, 0.1, 0.5, 0.01);
+        Particle skyburstParticle = TraitParticleResolver.getTraitParticle("skyburst", Particle.CLOUD);
+        player.getWorld().spawnParticle(skyburstParticle, horse.getLocation(), 20, 0.5, 0.1, 0.5, 0.01);
         player.playSound(horse.getLocation(), Sound.ENTITY_GENERIC_EXPLODE, 1.0f, 1.2f);
 
         for (Entity entity : horse.getNearbyEntities(radius, radius, radius)) {
@@ -260,7 +262,8 @@ public class TraitRegistry {
                 System.currentTimeMillis() + duration * 1000L
         );
 
-        horse.getWorld().spawnParticle(Particle.WITCH, horse.getLocation(), 25, 0.6, 0.6, 0.6, 0.05);
+        Particle revenantParticle = TraitParticleResolver.getTraitParticle("revenantcurse", Particle.WITCH);
+        horse.getWorld().spawnParticle(revenantParticle, horse.getLocation(), 25, 0.6, 0.6, 0.6, 0.05);
         horse.getWorld().playSound(horse.getLocation(), Sound.ENTITY_WITHER_AMBIENT, 1, 0.8f);
 
         setCooldown(horse, key, config.getInt("traits.revenantcurse.cooldown", 30));

--- a/BetterHorses/src/main/resources/config.yml
+++ b/BetterHorses/src/main/resources/config.yml
@@ -125,6 +125,7 @@ traits:
   hellmare:
     enabled: true
     chance: 0.005 # 0.5%
+    particle: FLAME
     duration: 5
     cooldown: 90
     radius: 2 # Radius of the fire below the horse
@@ -132,25 +133,30 @@ traits:
   fireheart:
     enabled: true
     chance: 0.01 # 1%
+    particle: LAVA
 
   dashboost:
     enabled: true
     chance: 0.01 # 1%
+    particle: SWEEP_ATTACK
     duration: 10
     cooldown: 30
 
   featherhooves:
     enabled: true
     chance: 0.01 # 1%
+    particle: CLOUD
 
   frosthooves:
     enabled: true
     chance: 0.005 # 0.5%
+    particle: SNOWFLAKE
     radius: 3 # Radius of the ice below the horse
 
   kickback:
     enabled: true
     chance: 0.005 # 0.5%
+    particle: CRIT
     radius: 4
     strength: 6
     cooldown: 20
@@ -158,23 +164,27 @@ traits:
   ghosthorse:
     enabled: true
     chance: 0.005 # 0.5%
+    particle: SMOKE
     duration: 5
     cooldown: 30
 
   skyburst:
     enabled: true
     chance: 0.003 # 0.3%
+    particle: CLOUD
     radius: 4
 
   revenantcurse:
     enabled: true
     chance: 0.005 # 0.5%
+    particle: SOUL
     cooldown: 30
     duration: 10
 
   heavenhooves:
     enabled: true
     chance: 0.001 # 0.1%
+    particle: GLOW
     strength: 0.4
     particles: true
 


### PR DESCRIPTION
### Motivation
- Allow server operators to configure the particle used for each trait via config so indicator/ability effects can be customized. 
- Prevent misconfigured particle names from throwing errors at runtime by providing a safe fallback and an informative console warning.

### Description
- Added `TraitParticleResolver` which reads `traits.<trait>.particle`, safely resolves `Particle` values, returns a provided fallback when invalid, and logs a single warning per unique invalid value using the plugin logger.
- Updated `TraitParticleTask` to request each trait's particle via `TraitParticleResolver.getTraitParticle(...)` instead of hardcoded `Particle` constants so the indicator uses the configured particle.
- Updated trait ability particle calls in `TraitRegistry` (Hellmare, HeavenHooves, Skyburst, Revenant Curse) to use `TraitParticleResolver` so ability effects also respect the config and fall back safely.
- Added `particle` default entries for every trait in `config.yml` so server owners have example/default values and can change them.

### Testing
- Ran `./gradlew build` in the repository, which failed in this environment with `Unsupported class file major version 69`, indicating a local Java/Gradle compatibility issue rather than a logic/runtime failure in the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2c595a904832ba08837354ba503b1)