### PR TITLE
Persist colored horse armor and enforce breeding restrictions in love-mode

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorseKeys.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorseKeys.java
@@ -26,6 +26,7 @@ public final class BetterHorseKeys {
     public static final NamespacedKey COOLDOWN = key("cooldown");
     public static final NamespacedKey SADDLE = key("saddle");
     public static final NamespacedKey ARMOR = key("armor");
+    public static final NamespacedKey ARMOR_DATA = key("armor_data");
     public static final NamespacedKey BASE_HEALTH = key("base_health");
     public static final NamespacedKey BASE_SPEED = key("base_speed");
     public static final NamespacedKey BASE_JUMP = key("base_jump");

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Base64;
 import java.util.Optional;
 
 public class BetterHorsesAPI {
@@ -164,6 +165,7 @@ public class BetterHorsesAPI {
         String colorStr = data.get(BetterHorseKeys.COLOR, PersistentDataType.STRING);
         String saddleStr = data.get(BetterHorseKeys.SADDLE, PersistentDataType.STRING);
         String armorStr = data.get(BetterHorseKeys.ARMOR, PersistentDataType.STRING);
+        String armorData = data.get(BetterHorseKeys.ARMOR_DATA, PersistentDataType.STRING);
         String customName = data.get(BetterHorseKeys.NAME, PersistentDataType.STRING);
         String trait = data.get(BetterHorseKeys.TRAIT, PersistentDataType.STRING);
         Byte neutered = data.get(BetterHorseKeys.NEUTERED, PersistentDataType.BYTE);
@@ -268,7 +270,10 @@ public class BetterHorsesAPI {
             horse.getInventory().setSaddle(new ItemStack(Material.valueOf(saddleStr)));
         }
         if (armorStr != null) {
-            HorseArmorUtils.setArmor(horse.getInventory(), new ItemStack(Material.valueOf(armorStr)));
+            ItemStack armorItem = restoreArmorItem(armorStr, armorData);
+            if (armorItem != null) {
+                HorseArmorUtils.setArmor(horse.getInventory(), armorItem);
+            }
         }
 
         return horse;
@@ -383,10 +388,28 @@ public class BetterHorsesAPI {
         if (isNeutered) itemData.set(neuterKey, PersistentDataType.BYTE, (byte) 1);
         if (cooldown != null) itemData.set(BetterHorseKeys.COOLDOWN, PersistentDataType.LONG, cooldown);
         if (saddle != null) itemData.set(BetterHorseKeys.SADDLE, PersistentDataType.STRING, saddle.getType().name());
-        if (armor != null) itemData.set(BetterHorseKeys.ARMOR, PersistentDataType.STRING, armor.getType().name());
+        if (armor != null) {
+            itemData.set(BetterHorseKeys.ARMOR, PersistentDataType.STRING, armor.getType().name());
+            itemData.set(BetterHorseKeys.ARMOR_DATA, PersistentDataType.STRING, Base64.getEncoder().encodeToString(armor.serializeAsBytes()));
+        }
 
         item.setItemMeta(meta);
         return item;
+    }
+
+    private static @Nullable ItemStack restoreArmorItem(String armorMaterial, @Nullable String serializedArmor) {
+        if (serializedArmor != null && !serializedArmor.isBlank()) {
+            try {
+                return ItemStack.deserializeBytes(Base64.getDecoder().decode(serializedArmor));
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+
+        try {
+            return new ItemStack(Material.valueOf(armorMaterial));
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
     }
 
     public static boolean isBetterHorse(Entity entity) {

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseBreedListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseBreedListener.java
@@ -15,12 +15,33 @@ import org.bukkit.entity.AbstractHorse;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityBreedEvent;
+import org.bukkit.event.entity.EntityEnterLoveModeEvent;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 
 import java.util.Set;
 
 public class HorseBreedListener implements Listener {
+
+    @EventHandler
+    public void onHorseEnterLoveMode(EntityEnterLoveModeEvent event) {
+        if (!(event.getEntity() instanceof AbstractHorse horse)) return;
+
+        SupportedMountType mountType = SupportedMountType.fromEntity(horse).orElse(null);
+        if (mountType == null) return;
+
+        FileConfiguration config = BetterHorses.getInstance().getConfig();
+        if (!mountType.isEnabled(config)) return;
+
+        if (isNeutered(horse) || isOnBreedingCooldown(horse, config)) {
+            event.setCancelled(true);
+            return;
+        }
+
+        if (horse.getAge() != 0) {
+            horse.setAge(0);
+        }
+    }
 
     @EventHandler
     public void onHorseBreed(EntityBreedEvent event) {
@@ -38,41 +59,16 @@ public class HorseBreedListener implements Listener {
         if (!childType.equals(fatherType) || !childType.equals(motherType)) return;
         if (!childType.isEnabled(config)) return;
 
-        long cooldownSeconds = config.getLong("settings.breeding-cooldown", 0);
-        long cooldownMillis = cooldownSeconds * 1000L;
+        father.setAge(0);
+        mother.setAge(0);
+
         long now = System.currentTimeMillis();
 
         PersistentDataContainer dataFather = father.getPersistentDataContainer();
         PersistentDataContainer dataMother = mother.getPersistentDataContainer();
 
-        // Cancel if either parent has cooldown that hasn't expired
-        if (dataFather.has(BetterHorseKeys.COOLDOWN, PersistentDataType.LONG) && !config.getBoolean("settings.male-ignore-cooldown")) {
-            long last = dataFather.get(BetterHorseKeys.COOLDOWN, PersistentDataType.LONG);
-            Double cooldownLeft = (cooldownMillis - (now - last)) / 1000.0;
-            if (cooldownLeft > 0) {
-                event.setCancelled(true);
-                return;
-            }
-        }
-        if (dataMother.has(BetterHorseKeys.COOLDOWN, PersistentDataType.LONG)) {
-            long last = dataMother.get(BetterHorseKeys.COOLDOWN, PersistentDataType.LONG);
-            Double cooldownLeft = (cooldownMillis - (now - last)) / 1000.0;
-            if (cooldownLeft > 0) {
-                event.setCancelled(true);
-                return;
-            }
-        }
-
         String gender1 = getGender(father);
         String gender2 = getGender(mother);
-
-        boolean motherNeutered = isNeutered(mother);
-        boolean fatherNeutered = isNeutered(father);
-
-        if (motherNeutered || fatherNeutered) {
-            event.setCancelled(true);
-            return;
-        }
 
         boolean allowSameGender = config.getBoolean("settings.allow-same-gender-breeding", false);
         if (!allowSameGender && gender1.equalsIgnoreCase(gender2)) {
@@ -147,6 +143,20 @@ public class HorseBreedListener implements Listener {
 
         father.setAge(0);
         mother.setAge(0);
+    }
+
+    private boolean isOnBreedingCooldown(AbstractHorse horse, FileConfiguration config) {
+        PersistentDataContainer data = horse.getPersistentDataContainer();
+        Long last = data.get(BetterHorseKeys.COOLDOWN, PersistentDataType.LONG);
+        if (last == null) return false;
+
+        String gender = getGender(horse);
+        if ("male".equalsIgnoreCase(gender) && config.getBoolean("settings.male-ignore-cooldown")) {
+            return false;
+        }
+
+        long cooldownMillis = config.getLong("settings.breeding-cooldown", 0) * 1000L;
+        return cooldownMillis > 0 && (System.currentTimeMillis() - last) < cooldownMillis;
     }
 
     private String getGender(AbstractHorse horse) {


### PR DESCRIPTION
### Motivation
- Preserve full horse armor metadata (including dye/color) across despawn/respawn so dyed armor is not lost when converting horses to items and back.
- Enforce neuter and custom breeding cooldowns at the moment horses enter love mode so the plugin controls whether breeding can begin while letting vanilla breeding logic run for offspring creation.
- Ensure parents remain at age 0 during the breeding flow so Minecraft's internal breeding checks permit breeding while the plugin applies cooldowns.

### Description
- Added a new namespaced key `ARMOR_DATA` to store serialized armor payloads for horse items.
- When converting a horse into an item (`toItem`) the armor `ItemStack` is serialized to bytes and saved as Base64 under `ARMOR_DATA`; when spawning a horse from an item (`toHorse`) the code attempts to deserialize that payload and restore the exact armor `ItemStack`, falling back to material-only restoration on failure.
- Introduced a `restoreArmorItem` helper to safely deserialize saved armor and gracefully handle older/invalid payloads.
- Added an `EntityEnterLoveModeEvent` handler that cancels love-mode for neutered horses and horses on the plugin breeding cooldown, removed the prior cooldown/neuter cancels from the `EntityBreedEvent`, and added an `isOnBreedingCooldown` helper to centralize cooldown checks.
- Ensure both parents are set to age `0` during the breed handling so vanilla breeding checks succeed while plugin cooldown bookkeeping is applied.

### Testing
- Attempted a local build with `./gradlew build -x test` which failed in this environment with `Unsupported class file major version 69`, indicating a Java/Gradle toolchain compatibility issue rather than an obvious compilation error in the changes.
- No automated unit tests were run or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2cd5dc754832bb06fd4c193bf9cf6)