### PR TITLE
Fix training lore visibility and add configurable horse-item lore layout

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
@@ -34,6 +34,7 @@ import org.bukkit.persistence.PersistentDataType;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Base64;
@@ -58,15 +59,7 @@ public class BetterHorsesAPI {
 
         ItemStack item = new ItemStack(material);
         ItemMeta meta = item.getItemMeta();
-        List<String> lore = new ArrayList<>();
-
         int growth = growthStage > 10 || growthStage < 1 ? 10 : growthStage;
-
-        lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-gender", "%value%", genderSymbol));
-        lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-health", "%value%", String.format("%.2f", health), "%max%", String.format("%.2f", health)));
-        lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-speed", "%value%", String.format("%.4f", speed)));
-        lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-jump", "%value%", String.format("%.4f", jump)));
-        lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-growth", "%value%", String.format("%d", growth)));
 
         PersistentDataContainer data = meta.getPersistentDataContainer();
         data.set(BetterHorseKeys.GENDER, PersistentDataType.STRING, gender);
@@ -86,9 +79,9 @@ public class BetterHorsesAPI {
             data.set(BetterHorseKeys.NEUTERED, PersistentDataType.BYTE, (byte) 1);
         }
         TrainingManager.ensureTrainingData(data);
-        TrainingManager.ensureTrainingLorePresent(lore, data);
 
         FileConfiguration config = plugin.getConfig();
+        String traitForLore = null;
         if (config.getBoolean("traits.enabled")) {
             ConfigurationSection traitsSection = config.getConfigurationSection("traits");
 
@@ -97,14 +90,7 @@ public class BetterHorsesAPI {
                     ConfigurationSection traitConfig = traitsSection.getConfigurationSection(traitOverride);
                     if (traitConfig.getBoolean("enabled", false)) {
                         data.set(BetterHorseKeys.TRAIT, PersistentDataType.STRING, traitOverride.toLowerCase());
-                        lore.add(ChatColor.GOLD + lang.getFormattedRaw("messages.trait-line", "%trait%", formatTraitName(traitOverride)));
-                        if(!isNeutered) {
-                            lore.add("");
-                        }
-                    }
-                    if (isNeutered) {
-                        lore.add(ChatColor.DARK_GRAY + lang.getRaw("messages.lore-neutered"));
-                        lore.add("");
+                        traitForLore = traitOverride;
                     }
                 }
             } else if (traitsSection != null) {
@@ -116,12 +102,26 @@ public class BetterHorsesAPI {
                     double chance = tSec.getDouble("chance", 0);
                     if (Math.random() < chance) {
                         data.set(BetterHorseKeys.TRAIT, PersistentDataType.STRING, trait.toLowerCase());
-                        lore.add(ChatColor.GOLD + lang.getFormattedRaw("messages.trait-line", "%trait%", formatTraitName(trait)));
+                        traitForLore = trait;
                         break;
                     }
                 }
             }
         }
+
+        List<String> lore = buildHorseLore(
+                config,
+                lang,
+                data,
+                genderSymbol,
+                health,
+                health,
+                speed,
+                jump,
+                growth,
+                traitForLore,
+                isNeutered
+        );
 
         meta.setLore(lore);
         meta.setDisplayName(name);
@@ -340,21 +340,19 @@ public class BetterHorsesAPI {
         String name = horse.getCustomName() != null ? horse.getCustomName() : mountType.getDisplayName(lang);
         meta.setDisplayName(ChatColor.GOLD + name + " " + genderSymbol);
 
-        List<String> lore = new ArrayList<>();
-        lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-gender", "%value%", genderSymbol));
-        lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-health", "%value%", String.format("%.2f", currentHealth), "%max%", String.format("%.2f", maxHealth)));
-        lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-speed", "%value%", String.format("%.4f", speed)));
-        lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-jump", "%value%", String.format("%.4f", jump)));
-        lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-growth", "%value%", String.format("%d", growthStage)));
-        TrainingManager.ensureTrainingLorePresent(lore, data);
-        if (trait != null) {
-            lore.add(ChatColor.GOLD + lang.getFormattedRaw("messages.trait-line", "%trait%", formatTraitName(trait)));
-            if (!isNeutered) lore.add("");
-        }
-        if (isNeutered) {
-            lore.add(ChatColor.DARK_GRAY + lang.getRaw("messages.lore-neutered"));
-            lore.add("");
-        }
+        List<String> lore = buildHorseLore(
+                plugin.getConfig(),
+                lang,
+                data,
+                genderSymbol,
+                currentHealth,
+                maxHealth,
+                speed,
+                jump,
+                growthStage,
+                trait,
+                isNeutered
+        );
         meta.setLore(lore);
 
         if (horse.getCustomName() != null) {
@@ -410,6 +408,64 @@ public class BetterHorsesAPI {
         } catch (IllegalArgumentException ignored) {
             return null;
         }
+    }
+
+    private static List<String> buildHorseLore(
+            FileConfiguration config,
+            LanguageManager lang,
+            PersistentDataContainer data,
+            String genderSymbol,
+            double currentHealth,
+            double maxHealth,
+            double speed,
+            double jump,
+            int growth,
+            @Nullable String trait,
+            boolean isNeutered
+    ) {
+        List<String> lore = new ArrayList<>();
+        List<String> layout = config.getStringList("settings.horse-item-lore-layout");
+        if (layout.isEmpty()) {
+            layout = Arrays.asList("gender", "health", "speed", "jump", "growth", "blank", "training", "trait", "neutered", "blank");
+        }
+
+        for (String rawPart : layout) {
+            String part = rawPart == null ? "" : rawPart.trim().toLowerCase();
+            switch (part) {
+                case "gender" -> lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-gender", "%value%", genderSymbol));
+                case "health" -> lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-health", "%value%", String.format("%.2f", currentHealth), "%max%", String.format("%.2f", maxHealth)));
+                case "speed" -> lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-speed", "%value%", String.format("%.4f", speed)));
+                case "jump" -> lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-jump", "%value%", String.format("%.4f", jump)));
+                case "growth" -> lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-growth", "%value%", String.format("%d", growth)));
+                case "trait" -> {
+                    if (trait != null && !trait.isBlank()) {
+                        lore.add(ChatColor.GOLD + lang.getFormattedRaw("messages.trait-line", "%trait%", formatTraitName(trait)));
+                    }
+                }
+                case "neutered" -> {
+                    if (isNeutered) {
+                        lore.add(ChatColor.DARK_GRAY + lang.getRaw("messages.lore-neutered"));
+                    }
+                }
+                case "training" -> lore.addAll(TrainingManager.getTrainingLoreLines(data));
+                case "blank" -> lore.add("");
+                default -> {
+                    if (part.startsWith("literal:")) {
+                        lore.add(ChatColor.translateAlternateColorCodes('&', rawPart.substring("literal:".length())));
+                    }
+                }
+            }
+        }
+
+        return trimTrailingBlankLines(lore);
+    }
+
+    private static List<String> trimTrailingBlankLines(List<String> input) {
+        List<String> trimmed = new ArrayList<>(input);
+        while (!trimmed.isEmpty() && trimmed.get(trimmed.size() - 1).isBlank()) {
+            trimmed.remove(trimmed.size() - 1);
+        }
+        return trimmed;
     }
 
     public static boolean isBetterHorse(Entity entity) {

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java
@@ -119,19 +119,32 @@ public final class TrainingManager {
 
     public static List<String> getTrainingLoreLines(PersistentDataContainer data) {
         FileConfiguration config = BetterHorses.getInstance().getConfig();
+        List<String> lines = new ArrayList<>();
+        if (!isTrainingLoreEnabled(config)) return lines;
+
+        lines.add("");
+        lines.addAll(getTrainingLoreContentLines(data));
+        lines.add("");
+        return lines;
+    }
+
+    public static List<String> getTrainingLoreContentLines(PersistentDataContainer data) {
+        FileConfiguration config = BetterHorses.getInstance().getConfig();
         FileConfiguration language = BetterHorses.getInstance().getLang().getConfig();
         List<String> lines = new ArrayList<>();
         if (!isTrainingEnabled(config)) return lines;
 
         ensureTrainingData(data);
 
-        lines.add("");
         lines.add(color(language.getString("training-lore.title", "&6Training")));
         addCategoryLore(lines, config, language, data, "riding", BetterHorseKeys.TRAINING_RIDING_UNITS, "&7Riding: %bar% &b%percent%%");
         addCategoryLore(lines, config, language, data, "brushing", BetterHorseKeys.TRAINING_BRUSHING_UNITS, "&7Brushing: %bar% &b%percent%%");
         addCategoryLore(lines, config, language, data, "feeding", BetterHorseKeys.TRAINING_FEEDING_UNITS, "&7Feeding: %bar% &b%percent%%");
-        lines.add("");
         return lines;
+    }
+
+    public static boolean isTrainingLoreEnabled(FileConfiguration config) {
+        return isTrainingEnabled(config) && config.getBoolean("training.lore.enabled", true);
     }
 
     public static void ensureTrainingLorePresent(List<String> lore, PersistentDataContainer data) {

--- a/BetterHorses/src/main/resources/config.yml
+++ b/BetterHorses/src/main/resources/config.yml
@@ -71,6 +71,21 @@ settings:
   # Customizes the original item a horse item is
   horse-item: SADDLE
 
+  # Controls which lore parts are shown for horse items and in what order.
+  # Available values: gender, health, speed, jump, growth, training, trait, neutered, blank
+  # You can also add literal custom lines with: literal:&7Your custom text
+  horse-item-lore-layout:
+    - gender
+    - health
+    - speed
+    - jump
+    - growth
+    - blank
+    - training
+    - trait
+    - neutered
+    - blank
+
   # Allow additional mount types to be treated like BetterHorses horses
   mount-types:
     skeleton-horses: true
@@ -194,6 +209,9 @@ training:
   enabled: true
 
   lore:
+    # Controls whether training information should be displayed on horse-item lore.
+    enabled: true
+
     progress-bar:
       length: 15
 


### PR DESCRIPTION
### Motivation
- Training lines were not reliably shown on horse-item lore even when enabled, and lore construction was duplicated across code paths which caused inconsistencies.  
- Provide server admins the ability to arrange and customize the exact ordering and presence of all horse-item lore lines.

### Description
- Centralized horse-item lore construction into a single `buildHorseLore(...)` helper and replaced duplicated inline lore assembly in `createHorseItem` and `toItem` with calls to that method (file: `BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java`).
- Fixed training-lore rendering by splitting training lore generation into `getTrainingLoreLines(...)` and `getTrainingLoreContentLines(...)` and added `isTrainingLoreEnabled(...)` so training entries are included only when `training.lore.enabled` is `true` (file: `BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java`).
- Added a new configuration option `settings.horse-item-lore-layout` that accepts a list of tokens to fully control lore composition and ordering, and supports literal lines via `literal:<text>` (file: `BetterHorses/src/main/resources/config.yml`).
- Added helper `trimTrailingBlankLines(...)` to clean up final lore formatting and included support for tokens: `gender`, `health`, `speed`, `jump`, `growth`, `training`, `trait`, `neutered`, `blank`, and `literal:<text>`.

### Testing
- Ran the project tests with `./gradlew test` in the `BetterHorses` subproject; the build failed during Gradle script analysis with `Unsupported class file major version 69`, indicating a Java/Gradle toolchain incompatibility in this environment, so no plugin tests executed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2d0eae090832b9f7a1848e3385f93)