### PR TITLE
Add language.yml to missing-value auto-updater

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
@@ -50,7 +50,8 @@ public class BetterHorses extends JavaPlugin {
         }
         instance = this;
         saveDefaultConfig();
-        updateConfigWithMissingSections();
+        updateYamlWithMissingSections("config.yml", false);
+        updateYamlWithMissingSections("language.yml", true);
         languageManager = new LanguageManager(this);
 
         registerListeners();
@@ -84,34 +85,38 @@ public class BetterHorses extends JavaPlugin {
     }
 
     public void reloadPluginConfiguration() {
-        updateConfigWithMissingSections();
+        updateYamlWithMissingSections("config.yml", false);
+        updateYamlWithMissingSections("language.yml", true);
         reloadConfig();
         languageManager.reload();
         applyHorseCommandAliases();
         debugLog("PLUGIN", "RELOAD", true, "Configuration and language files were reloaded.");
     }
 
-    private void updateConfigWithMissingSections() {
-        File configFile = new File(getDataFolder(), "config.yml");
-        if (!configFile.exists()) {
-            return;
+    private void updateYamlWithMissingSections(String fileName, boolean saveDefaultWhenMissing) {
+        File file = new File(getDataFolder(), fileName);
+        if (!file.exists()) {
+            if (!saveDefaultWhenMissing) {
+                return;
+            }
+            saveResource(fileName, false);
         }
 
-        YamlConfiguration currentConfig = YamlConfiguration.loadConfiguration(configFile);
+        YamlConfiguration currentConfig = YamlConfiguration.loadConfiguration(file);
         YamlConfiguration defaultConfig;
 
-        try (InputStream defaultConfigStream = getResource("config.yml")) {
+        try (InputStream defaultConfigStream = getResource(fileName)) {
             if (defaultConfigStream == null) {
-                getLogger().warning("Default config.yml resource was not found; skipping config update.");
-                debugLog("CONFIG", "UPDATE", false, "Missing default config.yml resource.");
+                getLogger().warning("Default " + fileName + " resource was not found; skipping file update.");
+                debugLog("CONFIG", "UPDATE", false, "Missing default resource: " + fileName + ".");
                 return;
             }
             defaultConfig = YamlConfiguration.loadConfiguration(
                     new InputStreamReader(defaultConfigStream, StandardCharsets.UTF_8)
             );
         } catch (IOException exception) {
-            getLogger().log(Level.WARNING, "Failed to read default config.yml while updating config.", exception);
-            debugLog("CONFIG", "UPDATE", false, "Unable to read default config.yml: " + exception.getMessage());
+            getLogger().log(Level.WARNING, "Failed to read default " + fileName + " while updating file.", exception);
+            debugLog("CONFIG", "UPDATE", false, "Unable to read default file " + fileName + ": " + exception.getMessage());
             return;
         }
 
@@ -121,13 +126,13 @@ public class BetterHorses extends JavaPlugin {
         }
 
         try {
-            currentConfig.save(configFile);
+            currentConfig.save(file);
             reloadConfig();
-            getLogger().info("Updated config.yml with newly added default values.");
-            debugLog("CONFIG", "UPDATE", true, "Added missing config entries from default config.yml.");
+            getLogger().info("Updated " + fileName + " with newly added default values.");
+            debugLog("CONFIG", "UPDATE", true, "Added missing entries from default " + fileName + ".");
         } catch (IOException exception) {
-            getLogger().log(Level.WARNING, "Failed to save updated config.yml.", exception);
-            debugLog("CONFIG", "UPDATE", false, "Failed to save updated config.yml: " + exception.getMessage());
+            getLogger().log(Level.WARNING, "Failed to save updated " + fileName + ".", exception);
+            debugLog("CONFIG", "UPDATE", false, "Failed to save updated " + fileName + ": " + exception.getMessage());
         }
     }
 


### PR DESCRIPTION
### Motivation
- Keep `language.yml` in sync with bundled defaults by inserting missing keys without overwriting user-customized values, matching the existing `config.yml` behavior.

### Description
- Replaced the config-only updater with a reusable `updateYamlWithMissingSections(String fileName, boolean saveDefaultWhenMissing)` helper and wired it into startup and reload flows.
- The new helper loads the target YAML, reads the default resource in UTF-8, inserts only missing sections/keys via the existing `addMissingConfigValues` logic, and saves the file if changes were made.
- `language.yml` is now created from the bundled resource when missing (`saveDefaultWhenMissing = true`) while `config.yml` preserves the previous behavior (`saveDefaultWhenMissing = false`).

### Testing
- Ran `./gradlew test` in the project; the run failed in this environment with `Unsupported class file major version 69` during Gradle script semantic analysis, so automated test execution could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2d53646f4832b88d11d45e72f2816)