### PR TITLE
Preserve comments and formatting when updating config/language YAML

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
@@ -103,6 +103,7 @@ public class BetterHorses extends JavaPlugin {
         }
 
         YamlConfiguration currentConfig = YamlConfiguration.loadConfiguration(file);
+        currentConfig.options().parseComments(true);
         YamlConfiguration defaultConfig;
 
         try (InputStream defaultConfigStream = getResource(fileName)) {
@@ -114,6 +115,7 @@ public class BetterHorses extends JavaPlugin {
             defaultConfig = YamlConfiguration.loadConfiguration(
                     new InputStreamReader(defaultConfigStream, StandardCharsets.UTF_8)
             );
+            defaultConfig.options().parseComments(true);
         } catch (IOException exception) {
             getLogger().log(Level.WARNING, "Failed to read default " + fileName + " while updating file.", exception);
             debugLog("CONFIG", "UPDATE", false, "Unable to read default file " + fileName + ": " + exception.getMessage());
@@ -143,6 +145,8 @@ public class BetterHorses extends JavaPlugin {
             String fullPath = parentPath.isEmpty() ? key : parentPath + "." + key;
             Object defaultValue = defaults.get(key);
 
+            changed |= syncConfigComments(target, defaults, key);
+
             if (defaultValue instanceof ConfigurationSection defaultSection) {
                 if (!target.isConfigurationSection(key)) {
                     target.createSection(key);
@@ -160,6 +164,24 @@ public class BetterHorses extends JavaPlugin {
                 target.set(key, defaultValue);
                 changed = true;
             }
+        }
+
+        return changed;
+    }
+
+    private boolean syncConfigComments(ConfigurationSection target, ConfigurationSection defaults, String key) {
+        boolean changed = false;
+
+        List<String> defaultComments = defaults.getComments(key);
+        if (!defaultComments.equals(target.getComments(key))) {
+            target.setComments(key, defaultComments);
+            changed = true;
+        }
+
+        List<String> defaultInlineComments = defaults.getInlineComments(key);
+        if (!defaultInlineComments.equals(target.getInlineComments(key))) {
+            target.setInlineComments(key, defaultInlineComments);
+            changed = true;
         }
 
         return changed;


### PR DESCRIPTION
### Motivation
- The YAML auto-updater previously dropped comments/inline comments and formatting when adding missing keys, making updated `config.yml` and `language.yml` harder to read and different from the original bundled templates.

### Description
- Enabled comment parsing on loaded YAML objects by calling `currentConfig.options().parseComments(true)` and `defaultConfig.options().parseComments(true)` so comment metadata is available during updates.
- Added `syncConfigComments(ConfigurationSection target, ConfigurationSection defaults, String key)` to copy block comments and inline comments from the default configuration into the target section.
- Invoked `syncConfigComments` from `addMissingConfigValues` so comments are synchronized while still only adding missing keys/sections.

### Testing
- Ran `./gradlew build` in the `BetterHorses/` module as an automated validation step and the build failed with `Unsupported class file major version 69` during Gradle script semantic analysis, so compilation could not be verified in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2d8cdfbc0832b9bc4cc00220fb749)