### PR TITLE
Preserve configured blank lines in horse-item lore when training section is absent

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
@@ -429,31 +429,45 @@ public class BetterHorsesAPI {
             layout = Arrays.asList("gender", "health", "speed", "jump", "growth", "blank", "training", "trait", "neutered", "blank");
         }
 
+        int pendingBlankLines = 0;
+
         for (String rawPart : layout) {
             String part = rawPart == null ? "" : rawPart.trim().toLowerCase();
+            List<String> sectionLines = new ArrayList<>();
+
             switch (part) {
-                case "gender" -> lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-gender", "%value%", genderSymbol));
-                case "health" -> lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-health", "%value%", String.format("%.2f", currentHealth), "%max%", String.format("%.2f", maxHealth)));
-                case "speed" -> lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-speed", "%value%", String.format("%.4f", speed)));
-                case "jump" -> lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-jump", "%value%", String.format("%.4f", jump)));
-                case "growth" -> lore.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-growth", "%value%", String.format("%d", growth)));
+                case "gender" -> sectionLines.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-gender", "%value%", genderSymbol));
+                case "health" -> sectionLines.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-health", "%value%", String.format("%.2f", currentHealth), "%max%", String.format("%.2f", maxHealth)));
+                case "speed" -> sectionLines.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-speed", "%value%", String.format("%.4f", speed)));
+                case "jump" -> sectionLines.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-jump", "%value%", String.format("%.4f", jump)));
+                case "growth" -> sectionLines.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-growth", "%value%", String.format("%d", growth)));
                 case "trait" -> {
                     if (trait != null && !trait.isBlank()) {
-                        lore.add(ChatColor.GOLD + lang.getFormattedRaw("messages.trait-line", "%trait%", formatTraitName(trait)));
+                        sectionLines.add(ChatColor.GOLD + lang.getFormattedRaw("messages.trait-line", "%trait%", formatTraitName(trait)));
                     }
                 }
                 case "neutered" -> {
                     if (isNeutered) {
-                        lore.add(ChatColor.DARK_GRAY + lang.getRaw("messages.lore-neutered"));
+                        sectionLines.add(ChatColor.DARK_GRAY + lang.getRaw("messages.lore-neutered"));
                     }
                 }
-                case "training" -> lore.addAll(TrainingManager.getTrainingLoreLines(data));
-                case "blank" -> lore.add("");
+                case "training" -> sectionLines.addAll(TrainingManager.getTrainingLoreLines(data));
+                case "blank" -> pendingBlankLines++;
                 default -> {
                     if (part.startsWith("literal:")) {
-                        lore.add(ChatColor.translateAlternateColorCodes('&', rawPart.substring("literal:".length())));
+                        sectionLines.add(ChatColor.translateAlternateColorCodes('&', rawPart.substring("literal:".length())));
                     }
                 }
+            }
+
+            if (!sectionLines.isEmpty()) {
+                for (int i = 0; i < pendingBlankLines; i++) {
+                    if (!lore.isEmpty()) {
+                        lore.add("");
+                    }
+                }
+                pendingBlankLines = 0;
+                lore.addAll(sectionLines);
             }
         }
 


### PR DESCRIPTION
### Motivation
- Ensure the empty lines configured via `settings.horse-item-lore-layout` are preserved as the author intended even when optional sections like `training` produce no lines.
- Prevent extra or misaligned blank lines in horse item lore resulting from conditional/optional sections being omitted.

### Description
- Updated `buildHorseLore` in `BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java` to buffer `blank` layout entries using a `pendingBlankLines` counter and only emit them when a subsequent non-empty section is actually added.
- Converted per-layout output to accumulate `sectionLines` for each layout part (including `training` and `literal:`) and emit buffered blanks immediately before adding those lines.
- Kept the existing trailing-blank cleanup by returning the result through `trimTrailingBlankLines` so no unintended trailing blank lines remain.

### Testing
- Ran the automated test task `./gradlew test`, which failed in this environment due to a Java/Gradle compatibility issue (`Unsupported class file major version 69`) unrelated to the change, so no test failures attributable to the logic change were observed.
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2daf0e9f8832b8f80f59f1479693d)