### PR TITLE
Expand `/horse info` to show all known horse and horse-item values

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseInfoCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseInfoCommand.java
@@ -16,6 +16,12 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
 public final class HorseInfoCommand {
 
     private HorseInfoCommand() {
@@ -74,6 +80,8 @@ public final class HorseInfoCommand {
                     player.sendMessage(ChatColor.GRAY + "  - " + key + ChatColor.WHITE + " = " + renderedValue);
                 }
             }
+
+            sendKnownHorseDataValues(player, container, "Known BetterHorses Values (item)");
         }
 
         boolean inspectedMount = inspectMountedHorse(player, plugin);
@@ -120,11 +128,86 @@ public final class HorseInfoCommand {
                 + data.getOrDefault(BetterHorseKeys.GENDER, PersistentDataType.STRING, "<none>"));
         player.sendMessage(ChatColor.YELLOW + "Growth Stage: " + ChatColor.WHITE
                 + data.getOrDefault(BetterHorseKeys.GROWTH_STAGE, PersistentDataType.INTEGER, -1));
-        player.sendMessage(ChatColor.YELLOW + "Neutered: " + ChatColor.WHITE
-                + data.getOrDefault(BetterHorseKeys.NEUTERED, PersistentDataType.INTEGER, 0));
+        player.sendMessage(ChatColor.YELLOW + "Neutered: " + ChatColor.WHITE + resolveBooleanFlag(data, BetterHorseKeys.NEUTERED));
+
+        sendKnownHorseDataValues(player, data, "Known BetterHorses Values (mounted horse)");
+
         plugin.debugLog("HORSE_INFO", "MOUNT_SCAN", true,
                 "Player " + player.getName() + " inspected mounted horse " + horse.getUniqueId() + ".");
         return true;
+    }
+
+    private static void sendKnownHorseDataValues(Player player, PersistentDataContainer container, String title) {
+        player.sendMessage(ChatColor.YELLOW + title + ":");
+        for (NamespacedKey key : getKnownHorseKeys()) {
+            boolean present = container.getKeys().contains(key);
+            String renderedValue = resolveKnownValue(container, key);
+            String state = present ? ChatColor.GREEN + "present" : ChatColor.RED + "missing";
+            player.sendMessage(ChatColor.GRAY + "  - " + key + ChatColor.WHITE + " = " + renderedValue
+                    + ChatColor.DARK_GRAY + " [" + state + ChatColor.DARK_GRAY + "]");
+        }
+    }
+
+    private static List<NamespacedKey> getKnownHorseKeys() {
+        List<NamespacedKey> keys = new ArrayList<>();
+        for (Field field : BetterHorseKeys.class.getDeclaredFields()) {
+            if (!Modifier.isStatic(field.getModifiers()) || field.getType() != NamespacedKey.class) {
+                continue;
+            }
+
+            try {
+                NamespacedKey key = (NamespacedKey) field.get(null);
+                if (key != null) {
+                    keys.add(key);
+                }
+            } catch (IllegalAccessException ignored) {
+                // Should not happen for public constants; skip inaccessible fields.
+            }
+        }
+        keys.sort(Comparator.comparing(NamespacedKey::toString));
+        return keys;
+    }
+
+    private static String resolveKnownValue(PersistentDataContainer container, NamespacedKey key) {
+        if (key.equals(BetterHorseKeys.NEUTERED)) {
+            return resolveBooleanFlag(container, key);
+        }
+        if (key.equals(BetterHorseKeys.TRAINING_BRUSH_COOLDOWN)
+                || key.equals(BetterHorseKeys.TRAINING_FEED_COOLDOWN)
+                || key.equals(BetterHorseKeys.COOLDOWN)) {
+            return resolveTimestamp(container, key);
+        }
+        if (container.getKeys().contains(key)) {
+            return resolveValue(container, key);
+        }
+        return "<missing>";
+    }
+
+    private static String resolveBooleanFlag(PersistentDataContainer container, NamespacedKey key) {
+        Byte byteValue = container.get(key, PersistentDataType.BYTE);
+        if (byteValue != null) {
+            return byteValue != 0 ? "true (byte=" + byteValue + ")" : "false (byte=0)";
+        }
+
+        Integer integerValue = container.get(key, PersistentDataType.INTEGER);
+        if (integerValue != null) {
+            return integerValue != 0 ? "true (int=" + integerValue + ")" : "false (int=0)";
+        }
+
+        return "<missing>";
+    }
+
+    private static String resolveTimestamp(PersistentDataContainer container, NamespacedKey key) {
+        Long timestamp = container.get(key, PersistentDataType.LONG);
+        if (timestamp == null) {
+            return "<missing>";
+        }
+
+        long delta = timestamp - System.currentTimeMillis();
+        if (delta > 0) {
+            return timestamp + " (active, " + (delta / 1000.0) + "s remaining)";
+        }
+        return timestamp + " (ready)";
     }
 
     private static String resolveValue(PersistentDataContainer container, NamespacedKey key) {


### PR DESCRIPTION
### Motivation
- The `/horse info` debug output only showed generic PDC entries and missed many BetterHorses-specific keys (training, cooldowns, flags), making debugging and support harder.
- The change aims to enumerate every stable key the plugin uses so both held horse items and mounted horses expose all stored values, including cooldowns and training progress.

### Description
- Added reflection-based enumeration of `BetterHorseKeys` and a new `sendKnownHorseDataValues` helper to print a "Known BetterHorses Values" section for items and mounted horses via `HorseInfoCommand`.
- Implemented `resolveKnownValue`, `resolveBooleanFlag`, and `resolveTimestamp` to render common cases more readably, where boolean flags (`neutered`) accept both `BYTE` and `INTEGER` and cooldown/timestamp keys show active/remaining or ready state.
- Integrated the known-key section into both item inspection (main hand item) and mounted-horse inspection, and sorted keys for stable output.
- Added imports for reflection/util types and minimal changes to existing output formatting to preserve previous info and extend it with the new sections.

### Testing
- Ran `./gradlew build` in `BetterHorses/` to validate compilation, but the build failed in this environment due to a local Java/Gradle compatibility issue (`Unsupported class file major version 69`), so no successful automated build was produced.
- No unit tests exist for the command; changes were limited to `HorseInfoCommand` and validated via static code inspection and local file compilation attempts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2e1e3a830832ba71352405238ddeb)