### PR TITLE
Fix duplicate training lore lines in horse item lore

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
@@ -553,7 +553,12 @@ public class BetterHorsesAPI {
                     sectionLines.add(ChatColor.DARK_GRAY + lang.getRaw("messages.lore-neutered"));
                 }
             }
-            case "training" -> sectionLines.addAll(TrainingManager.getTrainingLoreLines(data));
+            case "training" -> {
+                String titleLine = TrainingManager.getTrainingTitleLine();
+                if (!titleLine.isEmpty()) {
+                    sectionLines.add(titleLine);
+                }
+            }
             case "riding", "brushing", "feeding" -> {
                 String line = TrainingManager.getTrainingCategoryLine(data, part);
                 if (!line.isEmpty()) {

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java
@@ -126,6 +126,13 @@ public final class TrainingManager {
         return lines;
     }
 
+    public static String getTrainingTitleLine() {
+        FileConfiguration config = BetterHorses.getInstance().getConfig();
+        FileConfiguration language = BetterHorses.getInstance().getLang().getConfig();
+        if (!isTrainingLoreEnabled(config)) return "";
+        return color(language.getString("training-lore.title", "&6Training"));
+    }
+
     public static List<String> getTrainingLoreContentLines(PersistentDataContainer data) {
         FileConfiguration config = BetterHorses.getInstance().getConfig();
         FileConfiguration language = BetterHorses.getInstance().getLang().getConfig();
@@ -181,7 +188,7 @@ public final class TrainingManager {
         List<String> trainingLines = getTrainingLoreLines(data);
         if (trainingLines.isEmpty()) return;
 
-        String titleLine = trainingLines.size() > 1 ? trainingLines.get(1) : trainingLines.get(0);
+        String titleLine = trainingLines.get(0);
         String normalizedTitle = ChatColor.stripColor(titleLine);
         boolean hasTrainingTitle = lore.stream()
                 .map(ChatColor::stripColor)


### PR DESCRIPTION
### Motivation
- The `training` layout node was inserting the entire training block while child nodes (`riding`/`brushing`/`feeding`) also added their lines, causing duplicate training lore entries on horse items.

### Description
- Change `BetterHorsesAPI.resolveHorseLoreLines` so the `training` token only contributes the training header by calling a new helper instead of adding the full training block.
- Add `TrainingManager.getTrainingTitleLine()` to centralize title generation and respect the training-lore enablement check.
- Update `TrainingManager.ensureTrainingLorePresent` to determine the training title using the actual first training line (`trainingLines.get(0)`) when checking for existing lore before appending.

### Testing
- Ran `./gradlew test` in the plugin module (`BetterHorses/`) but the build failed with `Unsupported class file major version 69` during Gradle script analysis, so unit tests could not be executed.
- No other automated tests were run; changes were validated by static inspection and local repository diffs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2e5954748832b81b4f251ab43a24e)