### PR TITLE
Normalize trait keys before activation to fix swap-hands ability trigger

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/TraitActivationListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/TraitActivationListener.java
@@ -43,9 +43,9 @@ public class TraitActivationListener implements Listener {
             return;
         }
 
-        String selectedTrait = abilityEvent.getTraitKey();
+        String selectedTrait = normalizeTraitKey(abilityEvent.getTraitKey());
         plugin.debugLog("TRAIT_ACTIVATION", "TRIGGER", true, "Player " + player.getName() + " activated trait " + selectedTrait + ".");
-        switch (selectedTrait.toLowerCase()) {
+        switch (selectedTrait) {
             case "hellmare":
                 TraitRegistry.activateHellmare(player, mount);
                 break;
@@ -61,8 +61,28 @@ public class TraitActivationListener implements Listener {
             case "revenantcurse":
                 TraitRegistry.activateRevenantCurse(player, mount);
                 break;
+            default:
+                plugin.debugLog(
+                        "TRAIT_ACTIVATION",
+                        "UNKNOWN_TRAIT",
+                        false,
+                        "No active ability mapping exists for trait key '" + abilityEvent.getTraitKey() + "'."
+                );
+                break;
         }
 
         event.setCancelled(true); // Prevent item swap
+    }
+
+    private String normalizeTraitKey(String traitKey) {
+        if (traitKey == null) {
+            return "";
+        }
+        return traitKey
+                .toLowerCase()
+                .replace("_", "")
+                .replace("-", "")
+                .replace(" ", "")
+                .trim();
     }
 }


### PR DESCRIPTION
### Motivation
- The trait ability wasn't executed when pressing the swap-hands key because trait identifiers with separators or alternate formatting (e.g. underscores, dashes, spaces) did not match the hard-coded switch cases.

### Description
- Normalize the trait key returned from `abilityEvent.getTraitKey()` via a new `normalizeTraitKey` helper before dispatching the activation switch. (`TraitActivationListener.java`).
- Replace the previous direct switch with one on the normalized key so variants like `dash_boost`, `dash-boost`, or `Dash Boost` match `dashboost`.
- Add a `default` branch that emits a debug log when a trait key cannot be mapped to an ability to improve diagnosability.

### Testing
- Ran `./gradlew test` to validate the change, but the build could not run in this environment due to a Java/Gradle compatibility error (`Unsupported class file major version 69`), so automated tests did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2e7b39d98832ba8e878c730792eeb)