### PR TITLE
Fix HorseInfoCommand cooldown state calculation

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseInfoCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseInfoCommand.java
@@ -202,17 +202,35 @@ public final class HorseInfoCommand {
 
     private static String resolveTimestamp(PersistentDataContainer container, NamespacedKey key) {
         Long timestamp = container.get(key, PersistentDataType.LONG);
-        final FileConfiguration config = BetterHorses.getInstance().getConfig();
-
         if (timestamp == null) {
             return "<missing>";
         }
 
-        long delta = timestamp - System.currentTimeMillis();
+        final FileConfiguration config = BetterHorses.getInstance().getConfig();
+        final long cooldownMillis = resolveCooldownMillis(config, key);
+        final long cooldownEnd = timestamp + cooldownMillis;
+
+        long delta = cooldownEnd - System.currentTimeMillis();
         if (delta > 0) {
             return timestamp + " (active, " + (delta / 1000.0) + "s remaining)";
         }
         return timestamp + " (ready)";
+    }
+
+    private static long resolveCooldownMillis(FileConfiguration config, NamespacedKey key) {
+        if (key.equals(BetterHorseKeys.COOLDOWN)) {
+            return Math.max(0L, config.getLong("settings.breeding-cooldown", 0L) * 1000L);
+        }
+
+        if (key.equals(BetterHorseKeys.TRAINING_BRUSH_COOLDOWN)) {
+            return Math.max(0L, config.getLong("training.categories.brushing.cooldown-seconds", 180L) * 1000L);
+        }
+
+        if (key.equals(BetterHorseKeys.TRAINING_FEED_COOLDOWN)) {
+            return Math.max(0L, config.getLong("training.categories.feeding.cooldown-seconds", 0L) * 1000L);
+        }
+
+        return 0L;
     }
 
     private static String resolveValue(PersistentDataContainer container, NamespacedKey key) {


### PR DESCRIPTION
### Motivation

- The PDC timestamp stored for cooldowns represents the time the cooldown was set (start), not the time it ends, so `resolveTimestamp` must add the configured cooldown duration when deciding if a value is `active` or `ready`.

### Description

- Updated `HorseInfoCommand.resolveTimestamp` to compute `cooldownEnd = storedTimestamp + configuredCooldown` and evaluate remaining time against `System.currentTimeMillis()`.
- Added `resolveCooldownMillis(FileConfiguration, NamespacedKey)` to map known cooldown keys to their config durations and return milliseconds for: `settings.breeding-cooldown`, `training.categories.brushing.cooldown-seconds`, and `training.categories.feeding.cooldown-seconds`.
- Kept the previous textual output format but changed the logic so the command reports `active` until `storedTimestamp + cooldown` has passed and `ready` afterwards.

### Testing

- Ran `./gradlew test` in the `BetterHorses` module, but the build failed in this environment due to a Java/Gradle toolchain mismatch (`Unsupported class file major version 69`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2eb73d1f4832b88377fd0ebaec558)