### PR TITLE
Replace completed training progress bars with localized complete message

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java
@@ -142,6 +142,23 @@ public final class TrainingManager {
         ensureTrainingData(data);
 
         lines.add(color(language.getString("training-lore.title", "&6Training")));
+
+        boolean hideOnComplete = config.getBoolean("training.lore.progress-bar.hide-on-complete", true);
+        boolean ridingEnabled = isCategoryEnabled(config, "riding");
+        boolean brushingEnabled = isCategoryEnabled(config, "brushing");
+        boolean feedingEnabled = isCategoryEnabled(config, "feeding");
+
+        boolean allEnabledComplete = hideOnComplete
+                && (!ridingEnabled || getProgressPercent(config, data, "riding", BetterHorseKeys.TRAINING_RIDING_UNITS) >= 100.0)
+                && (!brushingEnabled || getProgressPercent(config, data, "brushing", BetterHorseKeys.TRAINING_BRUSHING_UNITS) >= 100.0)
+                && (!feedingEnabled || getProgressPercent(config, data, "feeding", BetterHorseKeys.TRAINING_FEEDING_UNITS) >= 100.0)
+                && (ridingEnabled || brushingEnabled || feedingEnabled);
+
+        if (allEnabledComplete) {
+            lines.add(completeText(language));
+            return lines;
+        }
+
         addCategoryLore(lines, config, language, data, "riding", BetterHorseKeys.TRAINING_RIDING_UNITS, "&7Riding: %bar% &b%percent%%");
         addCategoryLore(lines, config, language, data, "brushing", BetterHorseKeys.TRAINING_BRUSHING_UNITS, "&7Brushing: %bar% &b%percent%%");
         addCategoryLore(lines, config, language, data, "feeding", BetterHorseKeys.TRAINING_FEEDING_UNITS, "&7Feeding: %bar% &b%percent%%");
@@ -169,6 +186,10 @@ public final class TrainingManager {
 
         double percent = getProgressPercent(config, data, category, key);
         int rounded = (int) Math.round(percent);
+        if (shouldReplaceWithComplete(config, percent)) {
+            return completeText(language);
+        }
+
         String bar = progressBar(config, language, percent);
         String defaultFormat = switch (category.toLowerCase()) {
             case "riding" -> "&7Riding: %bar% &b%percent%%";
@@ -223,9 +244,24 @@ public final class TrainingManager {
         if (!isCategoryEnabled(config, category)) return;
         double percent = getProgressPercent(config, data, category, key);
         int rounded = (int) Math.round(percent);
+        if (shouldReplaceWithComplete(config, percent)) {
+            lines.add(completeText(language));
+            return;
+        }
+
         String bar = progressBar(config, language, percent);
         String format = language.getString("training-lore.categories." + category, formatDefault);
         lines.add(color(format.replace("%bar%", bar).replace("%percent%", String.valueOf(rounded))));
+    }
+
+    private static boolean shouldReplaceWithComplete(FileConfiguration config, double percent) {
+        return config.getBoolean("training.lore.progress-bar.hide-on-complete", true) && percent >= 100.0;
+    }
+
+    private static String completeText(FileConfiguration language) {
+        String filledColor = color(language.getString("training-lore.progress-bar.filled-color", "&b"));
+        String complete = color(language.getString("training-lore.complete", "completed"));
+        return filledColor + ChatColor.stripColor(complete);
     }
 
     private static String progressBar(FileConfiguration config, FileConfiguration language, double percent) {

--- a/BetterHorses/src/main/resources/language.yml
+++ b/BetterHorses/src/main/resources/language.yml
@@ -64,12 +64,12 @@ traits:
 
 training-lore:
   title: "&6Training"
+  complete: "completed"
   progress-bar:
     filled-char: "■"
     empty-char: "■"
     filled-color: "&b"
     empty-color: "&8"
-    complete: "completed"
   categories:
     riding: "&7Riding: %bar% &b%percent%%"
     brushing: "&7Brushing: %bar% &b%percent%%"


### PR DESCRIPTION
### Motivation
- Improve training lore readability by hiding full progress bars and showing a localized "complete" message when configured.
- When all enabled training categories are complete, simplify lore to only show the title and a single complete line.

### Description
- Updated `TrainingManager` to replace per-category progress bar lines with a `training-lore.complete` message when `training.lore.progress-bar.hide-on-complete` is true. 
- Added an overall shortcut so when all enabled training categories are at 100% the lore contains only the title plus one complete line. 
- Added helper methods `shouldReplaceWithComplete` and `completeText` to centralize the complete-state check and rendering logic, using the configured `training-lore.progress-bar.filled-color`. 
- Introduced the `training-lore.complete` key in `language.yml` and removed the duplicate placement of that value.

### Testing
- Ran `./gradlew build` in the project root to validate the changes, which failed in this environment with `Unsupported class file major version 69` due to a JDK/Gradle mismatch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3a7d6f308832bb31e17109be157e5)