### PR TITLE
Collapse training lore into title when all enabled categories complete

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
@@ -554,7 +554,7 @@ public class BetterHorsesAPI {
                 }
             }
             case "training" -> {
-                String titleLine = TrainingManager.getTrainingTitleLine();
+                String titleLine = TrainingManager.getTrainingTitleLine(data);
                 if (!titleLine.isEmpty()) {
                     sectionLines.add(titleLine);
                 }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/training/TrainingManager.java
@@ -113,11 +113,17 @@ public final class TrainingManager {
         return section.getDouble(material.name(), 0.0);
     }
 
-    public static String getTrainingTitleLine() {
+    public static String getTrainingTitleLine(PersistentDataContainer data) {
         FileConfiguration config = BetterHorses.getInstance().getConfig();
         FileConfiguration language = BetterHorses.getInstance().getLang().getConfig();
         if (!isTrainingLoreEnabled(config)) return "";
-        return color(language.getString("training-lore.title", "&6Training"));
+
+        String title = color(language.getString("training-lore.title", "&6Training"));
+        if (!shouldCollapseToTitleComplete(config, data)) {
+            return title;
+        }
+
+        return title + " " + completeText(language);
     }
 
     public static boolean isTrainingLoreEnabled(FileConfiguration config) {
@@ -128,6 +134,7 @@ public final class TrainingManager {
         FileConfiguration config = BetterHorses.getInstance().getConfig();
         FileConfiguration language = BetterHorses.getInstance().getLang().getConfig();
         if (!isTrainingLoreEnabled(config) || !isCategoryEnabled(config, category)) return "";
+        if (shouldCollapseToTitleComplete(config, data)) return "";
 
         ensureTrainingData(data);
         NamespacedKey key = switch (category.toLowerCase()) {
@@ -179,6 +186,36 @@ public final class TrainingManager {
 
     private static boolean shouldReplaceWithComplete(FileConfiguration config, double percent) {
         return config.getBoolean("training.lore.progress-bar.hide-on-complete", true) && percent >= 100.0;
+    }
+
+    private static boolean shouldCollapseToTitleComplete(FileConfiguration config, PersistentDataContainer data) {
+        if (!config.getBoolean("training.lore.progress-bar.hide-on-complete", true)) {
+            return false;
+        }
+
+        ensureTrainingData(data);
+        String[] categories = {"riding", "brushing", "feeding"};
+        boolean hasEnabledCategory = false;
+
+        for (String category : categories) {
+            if (!isCategoryEnabled(config, category)) {
+                continue;
+            }
+
+            hasEnabledCategory = true;
+            NamespacedKey key = switch (category) {
+                case "riding" -> BetterHorseKeys.TRAINING_RIDING_UNITS;
+                case "brushing" -> BetterHorseKeys.TRAINING_BRUSHING_UNITS;
+                case "feeding" -> BetterHorseKeys.TRAINING_FEEDING_UNITS;
+                default -> null;
+            };
+
+            if (key == null || getProgressPercent(config, data, category, key) < 100.0) {
+                return false;
+            }
+        }
+
+        return hasEnabledCategory;
     }
 
     private static String completeText(FileConfiguration language) {


### PR DESCRIPTION
### Motivation
- Change the training lore behavior so that when every enabled training category is at 100% and the `training.lore.progress-bar.hide-on-complete` option is enabled, the configured completion text is appended to the `Training` title and the individual category lines are skipped.
- This makes completed horses display a concise completed marker on the title instead of repeating per-category completion lines.
- No skills were used for this change.

### Description
- Updated `TrainingManager.getTrainingTitleLine` to accept a `PersistentDataContainer` and append the localized `training-lore.complete` text to the title when the collapse condition is met.
- Added `shouldCollapseToTitleComplete(FileConfiguration, PersistentDataContainer)` which verifies that `hide-on-complete` is set and that every enabled category (`riding`, `brushing`, `feeding`) has reached 100% progress.
- Modified `getTrainingCategoryLine` to return an empty string when the collapse condition is active so per-category lines are omitted.
- Updated lore assembly in `BetterHorsesAPI` to pass the horse `PersistentDataContainer` into the title resolver.

### Testing
- Attempted `cd BetterHorses && ./gradlew build` as an automated verification, but the build failed in this environment with `Unsupported class file major version 69`, indicating a local Java/Gradle runtime compatibility issue rather than a code compile error in the patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3ea3eddec832bb411d27964234b1c)