### PR TITLE
Add toggleable shared horse riding with rear passenger seat

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
@@ -34,6 +34,7 @@ public class BetterHorses extends JavaPlugin {
     private LanguageManager languageManager;
     private boolean protocolLibAvailable = false;
     private ProtocolManager protocolManager;
+    private SharedHorseRideListener sharedHorseRideListener;
 
     @Override
     public void onEnable() {
@@ -74,6 +75,13 @@ public class BetterHorses extends JavaPlugin {
                 20L  // repeat every 1s
         );
         debugLog("PLUGIN", "ENABLE_COMPLETE", true, "BetterHorses plugin enabled successfully.");
+    }
+
+    @Override
+    public void onDisable() {
+        if (sharedHorseRideListener != null) {
+            sharedHorseRideListener.shutdown();
+        }
     }
 
     public static BetterHorses getInstance() {
@@ -270,6 +278,12 @@ public class BetterHorses extends JavaPlugin {
         if (config.getBoolean("settings.fix-step-height", true)) {
             pluginManager.registerEvents(new HorseStepHeightListener(), this);
             debugLog("LISTENER", "REGISTER", true, "Registered HorseStepHeightListener.");
+        }
+
+        if (config.getBoolean("settings.shared-riding.enabled", false)) {
+            sharedHorseRideListener = new SharedHorseRideListener(this);
+            pluginManager.registerEvents(sharedHorseRideListener, this);
+            debugLog("LISTENER", "REGISTER", true, "Registered SharedHorseRideListener.");
         }
 
         if (config.getBoolean("settings.mounted-damage-boost.enabled", false)) {

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/SharedHorseRideListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/SharedHorseRideListener.java
@@ -1,0 +1,259 @@
+package me.luisgamedev.betterhorses.listeners;
+
+import me.luisgamedev.betterhorses.BetterHorses;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.AbstractHorse;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.entity.EntityDismountEvent;
+import org.bukkit.event.entity.EntityRemoveFromWorldEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.util.Vector;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class SharedHorseRideListener implements Listener {
+
+    private final BetterHorses plugin;
+    private final Map<UUID, SharedSeat> sharedSeats = new HashMap<>();
+    private final BukkitTask seatUpdateTask;
+
+    public SharedHorseRideListener(BetterHorses plugin) {
+        this.plugin = plugin;
+        this.seatUpdateTask = Bukkit.getScheduler().runTaskTimer(plugin, this::updateSeats, 1L, 1L);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onSecondPlayerMount(PlayerInteractEntityEvent event) {
+        if (!(event.getRightClicked() instanceof AbstractHorse horse)) {
+            return;
+        }
+
+        Player secondRider = event.getPlayer();
+        if (!horse.isValid() || horse.isDead()) {
+            return;
+        }
+
+        if (isMountedOnSharedSeat(secondRider)) {
+            return;
+        }
+
+        if (sharedSeats.containsKey(horse.getUniqueId())) {
+            return;
+        }
+
+        Player primaryRider = getPrimaryRider(horse);
+        if (primaryRider == null || primaryRider.equals(secondRider)) {
+            return;
+        }
+
+        FileConfiguration config = plugin.getConfig();
+        if (!config.getBoolean("settings.shared-riding.enabled", false)) {
+            return;
+        }
+
+        event.setCancelled(true);
+
+        Location spawnLocation = horse.getLocation().clone();
+        ArmorStand seat = (ArmorStand) horse.getWorld().spawnEntity(spawnLocation, EntityType.ARMOR_STAND);
+        seat.setInvisible(true);
+        seat.setMarker(true);
+        seat.setSmall(true);
+        seat.setGravity(false);
+        seat.setInvulnerable(true);
+        seat.setPersistent(false);
+        seat.setCollidable(false);
+
+        horse.addPassenger(seat);
+
+        SharedSeat sharedSeat = new SharedSeat(horse.getUniqueId(), seat.getUniqueId(), secondRider.getUniqueId());
+        sharedSeats.put(horse.getUniqueId(), sharedSeat);
+
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            if (!seat.isValid() || !horse.isValid() || !secondRider.isOnline()) {
+                clearSharedSeat(horse.getUniqueId());
+                return;
+            }
+            if (!seat.addPassenger(secondRider)) {
+                clearSharedSeat(horse.getUniqueId());
+            }
+        });
+    }
+
+    @EventHandler
+    public void onEntityDismount(EntityDismountEvent event) {
+        Entity vehicle = event.getDismounted();
+        Entity entity = event.getEntity();
+
+        if (vehicle instanceof ArmorStand seat) {
+            UUID horseId = getHorseIdBySeat(seat.getUniqueId());
+            if (horseId != null) {
+                clearSharedSeat(horseId);
+            }
+            return;
+        }
+
+        if (vehicle instanceof AbstractHorse horse && entity instanceof Player) {
+            if (sharedSeats.containsKey(horse.getUniqueId())) {
+                clearSharedSeat(horse.getUniqueId());
+            }
+        }
+    }
+
+    @EventHandler
+    public void onEntityDeath(EntityDeathEvent event) {
+        if (event.getEntity() instanceof AbstractHorse horse) {
+            clearSharedSeat(horse.getUniqueId());
+        }
+    }
+
+    @EventHandler
+    public void onEntityRemove(EntityRemoveFromWorldEvent event) {
+        if (event.getEntity() instanceof AbstractHorse horse) {
+            clearSharedSeat(horse.getUniqueId());
+        }
+        if (event.getEntity() instanceof ArmorStand seat) {
+            UUID horseId = getHorseIdBySeat(seat.getUniqueId());
+            if (horseId != null) {
+                clearSharedSeat(horseId);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        Player player = event.getPlayer();
+        for (SharedSeat sharedSeat : new ArrayList<>(sharedSeats.values())) {
+            if (sharedSeat.secondaryPassengerId().equals(player.getUniqueId())) {
+                clearSharedSeat(sharedSeat.horseId());
+                continue;
+            }
+
+            Entity horseEntity = Bukkit.getEntity(sharedSeat.horseId());
+            if (!(horseEntity instanceof AbstractHorse horse)) {
+                clearSharedSeat(sharedSeat.horseId());
+                continue;
+            }
+
+            for (Entity passenger : horse.getPassengers()) {
+                if (passenger.getUniqueId().equals(player.getUniqueId())) {
+                    clearSharedSeat(sharedSeat.horseId());
+                    break;
+                }
+            }
+        }
+    }
+
+    private void updateSeats() {
+        FileConfiguration config = plugin.getConfig();
+        double backwardOffset = config.getDouble("settings.shared-riding.backward-offset", 0.7D);
+        double verticalOffset = config.getDouble("settings.shared-riding.vertical-offset", 0.35D);
+
+        List<UUID> toClear = new ArrayList<>();
+
+        for (SharedSeat seatData : sharedSeats.values()) {
+            Entity horseEntity = Bukkit.getEntity(seatData.horseId());
+            Entity seatEntity = Bukkit.getEntity(seatData.seatEntityId());
+            Entity secondPassengerEntity = Bukkit.getEntity(seatData.secondaryPassengerId());
+
+            if (!(horseEntity instanceof AbstractHorse horse)
+                    || !(seatEntity instanceof ArmorStand seat)
+                    || !(secondPassengerEntity instanceof Player secondPassenger)
+                    || !horse.isValid() || horse.isDead()
+                    || !seat.isValid()
+                    || !secondPassenger.isOnline() || secondPassenger.isDead()) {
+                toClear.add(seatData.horseId());
+                continue;
+            }
+
+            Player primaryRider = getPrimaryRider(horse);
+            if (primaryRider == null) {
+                toClear.add(seatData.horseId());
+                continue;
+            }
+
+            if (!horse.getPassengers().contains(seat)) {
+                horse.addPassenger(seat);
+            }
+
+            Vector backward = horse.getLocation().getDirection();
+            backward.setY(0.0D);
+            if (backward.lengthSquared() < 0.001D) {
+                backward = new Vector(0, 0, 1);
+            }
+            backward.normalize().multiply(-backwardOffset);
+
+            Location target = horse.getLocation().clone().add(backward).add(0.0D, verticalOffset, 0.0D);
+            seat.teleport(target);
+
+            if (!seat.getPassengers().contains(secondPassenger)) {
+                seat.addPassenger(secondPassenger);
+            }
+        }
+
+        for (UUID horseId : toClear) {
+            clearSharedSeat(horseId);
+        }
+    }
+
+    private Player getPrimaryRider(AbstractHorse horse) {
+        for (Entity passenger : horse.getPassengers()) {
+            if (passenger instanceof Player player) {
+                return player;
+            }
+        }
+        return null;
+    }
+
+    private boolean isMountedOnSharedSeat(Player player) {
+        Entity vehicle = player.getVehicle();
+        if (!(vehicle instanceof ArmorStand armorStand)) {
+            return false;
+        }
+        return getHorseIdBySeat(armorStand.getUniqueId()) != null;
+    }
+
+    private UUID getHorseIdBySeat(UUID seatId) {
+        for (SharedSeat seatData : sharedSeats.values()) {
+            if (seatData.seatEntityId().equals(seatId)) {
+                return seatData.horseId();
+            }
+        }
+        return null;
+    }
+
+    private void clearSharedSeat(UUID horseId) {
+        SharedSeat seatData = sharedSeats.remove(horseId);
+        if (seatData == null) {
+            return;
+        }
+
+        Entity seatEntity = Bukkit.getEntity(seatData.seatEntityId());
+        if (seatEntity != null && seatEntity.isValid()) {
+            seatEntity.remove();
+        }
+    }
+
+    public void shutdown() {
+        for (UUID horseId : new ArrayList<>(sharedSeats.keySet())) {
+            clearSharedSeat(horseId);
+        }
+        seatUpdateTask.cancel();
+    }
+
+    private record SharedSeat(UUID horseId, UUID seatEntityId, UUID secondaryPassengerId) {}
+}

--- a/BetterHorses/src/main/resources/config.yml
+++ b/BetterHorses/src/main/resources/config.yml
@@ -109,6 +109,12 @@ settings:
   # If enabled, players riding a horse cant be hit
   rider-invulnerable: false
 
+  # Allows two players to ride the same horse by placing the second player on an invisible armor stand seat
+  shared-riding:
+    enabled: false
+    backward-offset: 0.7
+    vertical-offset: 0.35
+
   # Fixes a vanilla bug where horses cant automatically climb from a path block onto a full block
   # because it exceeds their 1-block step height, only applies to mounted horses
   fix-step-height: true


### PR DESCRIPTION
### Motivation
- Allow two players to ride the same horse without the second player clipping inside the primary rider by mounting the second player on an offset invisible seat. 
- Make the feature configurable and safe by providing cleanup for dismounts, entity removal, and plugin shutdown.

### Description
- Added `SharedHorseRideListener` which spawns an invisible `ArmorStand` marker seat mounted to the horse and places the second player on that seat, keeping them offset behind the primary rider; seat position is updated every tick using configurable offsets.
- Wired the listener into plugin lifecycle: registration is controlled by `settings.shared-riding.enabled` and the listener is shut down on plugin disable to remove active seats.
- Added config entries `settings.shared-riding.enabled`, `settings.shared-riding.backward-offset`, and `settings.shared-riding.vertical-offset` in `config.yml` with sensible defaults.
- Implemented robust cleanup on player quit, dismount, horse death, entity removal, and when seat/players become invalid to avoid orphaned armor stands.

### Testing
- Executed `./gradlew build -x test` in this environment which failed due to a Java/Gradle compatibility error (`Unsupported class file major version 69`), so no successful artifact build could be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebca306408832b88373782cd987623)