### PR TITLE
Add PlaceholderAPI and MiniMessage parsing to LanguageManager

### DIFF
--- a/BetterHorses/build.gradle
+++ b/BetterHorses/build.gradle
@@ -13,11 +13,13 @@ repositories {
         url = 'https://repo.papermc.io/repository/maven-public/'
     }
     maven { url = "https://repo.dmulloy2.net/repository/public/" }
+    maven { url = "https://repo.extendedclip.com/releases/" }
 }
 
 dependencies {
     compileOnly 'io.papermc.paper:paper-api:1.20.6-R0.1-SNAPSHOT'
     compileOnly 'com.comphenix.protocol:ProtocolLib:5.3.0'
+    compileOnly 'me.clip:placeholderapi:2.11.6'
 }
 
 java {

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/language/LanguageManager.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/language/LanguageManager.java
@@ -1,15 +1,47 @@
 package me.luisgamedev.betterhorses.language;
 
+import me.clip.placeholderapi.PlaceholderAPI;
 import me.luisgamedev.betterhorses.BetterHorses;
-import org.bukkit.ChatColor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 
 import java.io.File;
+import java.util.Map;
 
 public class LanguageManager {
 
+    private static final Map<Character, String> LEGACY_MINIMESSAGE_TAGS = Map.ofEntries(
+            Map.entry('0', "black"),
+            Map.entry('1', "dark_blue"),
+            Map.entry('2', "dark_green"),
+            Map.entry('3', "dark_aqua"),
+            Map.entry('4', "dark_red"),
+            Map.entry('5', "dark_purple"),
+            Map.entry('6', "gold"),
+            Map.entry('7', "gray"),
+            Map.entry('8', "dark_gray"),
+            Map.entry('9', "blue"),
+            Map.entry('a', "green"),
+            Map.entry('b', "aqua"),
+            Map.entry('c', "red"),
+            Map.entry('d', "light_purple"),
+            Map.entry('e', "yellow"),
+            Map.entry('f', "white"),
+            Map.entry('k', "obfuscated"),
+            Map.entry('l', "bold"),
+            Map.entry('m', "strikethrough"),
+            Map.entry('n', "underlined"),
+            Map.entry('o', "italic")
+    );
+
     private final BetterHorses plugin;
+    private final MiniMessage miniMessage = MiniMessage.miniMessage();
+    private final LegacyComponentSerializer legacySerializer = LegacyComponentSerializer.legacySection();
     private FileConfiguration lang;
 
     public LanguageManager(BetterHorses plugin) {
@@ -30,12 +62,65 @@ public class LanguageManager {
     }
 
     public String get(String key) {
+        return get(null, key);
+    }
+
+    public String get(OfflinePlayer player, String key) {
+        return serialize(getComponent(player, key));
+    }
+
+    public Component getComponent(String key) {
+        return getComponent(null, key);
+    }
+
+    public Component getComponent(OfflinePlayer player, String key) {
         String prefix = getRaw("prefix");
-        return ChatColor.translateAlternateColorCodes('&', prefix + getRaw(key));
+        return parse(player, prefix + getRaw(key));
     }
 
     public String getFormatted(String key, Object... replacements) {
-        String message = get(key);
+        return getFormatted(null, key, replacements);
+    }
+
+    public String getFormatted(OfflinePlayer player, String key, Object... replacements) {
+        return serialize(getFormattedComponent(player, key, replacements));
+    }
+
+    public Component getFormattedComponent(String key, Object... replacements) {
+        return getFormattedComponent(null, key, replacements);
+    }
+
+    public Component getFormattedComponent(OfflinePlayer player, String key, Object... replacements) {
+        String message = getRaw("prefix") + getRaw(key);
+        return parse(player, replace(message, replacements));
+    }
+
+    public String getFormattedRaw(String key, Object... replacements) {
+        return getFormattedRaw(null, key, replacements);
+    }
+
+    public String getFormattedRaw(OfflinePlayer player, String key, Object... replacements) {
+        return serialize(getFormattedRawComponent(player, key, replacements));
+    }
+
+    public Component getFormattedRawComponent(String key, Object... replacements) {
+        return getFormattedRawComponent(null, key, replacements);
+    }
+
+    public Component getFormattedRawComponent(OfflinePlayer player, String key, Object... replacements) {
+        return parse(player, replace(getRaw(key), replacements));
+    }
+
+    public Component parse(OfflinePlayer player, String message) {
+        String placeholderParsed = parsePlaceholders(player, message);
+        return miniMessage.deserialize(convertLegacyFormatting(placeholderParsed));
+    }
+
+    public String parseToString(OfflinePlayer player, String message) {
+        return serialize(parse(player, message));
+    }
+
+    private String replace(String message, Object... replacements) {
         for (int i = 0; i < replacements.length - 1; i += 2) {
             String placeholder = String.valueOf(replacements[i]);
             String value = String.valueOf(replacements[i + 1]);
@@ -44,16 +129,39 @@ public class LanguageManager {
         return message;
     }
 
-    public String getFormattedRaw(String key, Object... replacements) {
-        String message = getRaw(key);
-        for (int i = 0; i < replacements.length - 1; i += 2) {
-            String placeholder = String.valueOf(replacements[i]);
-            String value = String.valueOf(replacements[i + 1]);
-            message = message.replace(placeholder, value);
+    private String parsePlaceholders(OfflinePlayer player, String message) {
+        if (player == null || !Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+            return message;
         }
-        return ChatColor.translateAlternateColorCodes('&', message);
+        return PlaceholderAPI.setPlaceholders(player, message);
     }
 
+    private String convertLegacyFormatting(String message) {
+        StringBuilder converted = new StringBuilder(message.length());
+        for (int i = 0; i < message.length(); i++) {
+            char current = message.charAt(i);
+            if (current == '&' && i + 1 < message.length()) {
+                char code = Character.toLowerCase(message.charAt(i + 1));
+                if (code == 'r') {
+                    converted.append("<reset>");
+                    i++;
+                    continue;
+                }
+                String tag = LEGACY_MINIMESSAGE_TAGS.get(code);
+                if (tag != null) {
+                    converted.append('<').append(tag).append('>');
+                    i++;
+                    continue;
+                }
+            }
+            converted.append(current);
+        }
+        return converted.toString();
+    }
+
+    private String serialize(Component component) {
+        return legacySerializer.serialize(component);
+    }
 
     public FileConfiguration getConfig() {
         return lang;

--- a/BetterHorses/src/main/resources/plugin.yml
+++ b/BetterHorses/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: BetterHorses
 main: me.luisgamedev.betterhorses.BetterHorses
 version: 6.0
 api-version: 1.20
-softdepend: [ ProtocolLib ]
+softdepend: [ ProtocolLib, PlaceholderAPI ]
 
 commands:
   horse:


### PR DESCRIPTION
### Motivation
- Enable resolving PlaceholderAPI placeholders and full MiniMessage tags (not just legacy color codes) in language strings so constructs like `<green>%player%</green>` and `<font:minecraft:uniform>...</font>` render correctly.
- Preserve existing APIs and backwards compatibility with `&`-style legacy formatting while providing Adventure `Component`-level access for richer formatting.

### Description
- Add `PlaceholderAPI` as a `compileOnly` dependency and register the ExtendedClip Maven repository, and add `PlaceholderAPI` to `softdepend` in `plugin.yml`.
- Replace the previous `ChatColor`-based translation with a MiniMessage-based pipeline using `MiniMessage` and `LegacyComponentSerializer`, and add new `Component`-returning helpers such as `getComponent(...)`, `getFormattedComponent(...)`, and `parse(...)` with `OfflinePlayer` overloads.
- Parse placeholders first using `PlaceholderAPI.setPlaceholders(...)`, then deserialize MiniMessage, and implement `convertLegacyFormatting(...)` to turn legacy `&` codes into MiniMessage tags for compatibility.
- Keep the old String-returning methods by serializing the resulting `Component` back to legacy text via `LegacyComponentSerializer` so existing call sites continue to work.

### Testing
- Attempted to run `./gradlew build`, but the build failed in this environment due to an incompatible Java/Gradle/Groovy runtime (`Unsupported class file major version 69`).
- No other automated tests were executed in this environment due to the build/runtime limitation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3697cf8400832ba7aa235fd6fdd652)