### PR TITLE
Add default-enabled mountable skeleton horses setting

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseSpawnListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseSpawnListener.java
@@ -10,6 +10,7 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.AbstractHorse;
+import org.bukkit.entity.SkeletonHorse;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.CreatureSpawnEvent;
@@ -31,7 +32,9 @@ public class HorseSpawnListener implements Listener {
         BetterHorses plugin = BetterHorses.getInstance();
         if (!(event.getEntity() instanceof AbstractHorse horse)) return;
         SupportedMountType mountType = SupportedMountType.fromEntity(horse).orElse(null);
-        if (mountType == null || !mountType.isEnabled(plugin.getConfig())) return;
+        if (mountType == null) return;
+        makeSkeletonHorseMountableIfEnabled(plugin, horse);
+        if (!mountType.isEnabled(plugin.getConfig())) return;
         if (event.getSpawnReason() != CreatureSpawnEvent.SpawnReason.NATURAL) return;
         plugin.debugLog("HORSE_SPAWN", "NATURAL", true, "Natural mount spawn detected for " + horse.getUniqueId() + ".");
 
@@ -80,5 +83,14 @@ public class HorseSpawnListener implements Listener {
         TrainingManager.recalculateAndApplyBonuses(horse);
         BetterHorsesAPI.callSpawnEvent(horse, null, BetterHorseSpawnEvent.SpawnCause.NATURAL);
         plugin.debugLog("HORSE_SPAWN", "COMPLETE", true, "Initialized natural mount " + horse.getUniqueId() + " stage=" + stage + ".");
+    }
+
+    private void makeSkeletonHorseMountableIfEnabled(BetterHorses plugin, AbstractHorse horse) {
+        if (!(horse instanceof SkeletonHorse)) return;
+        if (!plugin.getConfig().getBoolean("settings.mountable-skeleton-horses", true)) return;
+
+        horse.setTamed(true);
+        plugin.debugLog("HORSE_SPAWN", "SKELETON_MOUNTABLE", true,
+                "Marked skeleton horse " + horse.getUniqueId() + " as tamed for vanilla mounting.");
     }
 }

--- a/BetterHorses/src/main/resources/config.yml
+++ b/BetterHorses/src/main/resources/config.yml
@@ -103,6 +103,9 @@ settings:
   # Restricts mounting a tamed horse to its respective owner
   restrict-mounting-to-owner: false
 
+  # Makes every skeleton horse mountable like a vanilla horse, including skeleton horses spawned from spawn eggs
+  mountable-skeleton-horses: true
+
   # Allows spawning the horse by rightclicking with the horse item
   allow-rightclick-spawn: true
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ settings:
   # Allows two horses of the same gender to breed
   allow-same-gender-breeding: false
 
+  # Makes every skeleton horse mountable like a vanilla horse, including skeleton horses spawned from spawn eggs
+  mountable-skeleton-horses: true
+
   # Allows spawning the horse by rightclicking with the horse item
   allow-rightclick-spawn: true
 


### PR DESCRIPTION
### Motivation
- Vanilla skeleton horses are only mountable when naturally spawned, so provide an option to make all skeleton horses mountable by default, including those from spawn eggs.
- Allow server admins to opt out via configuration while keeping the feature enabled by default for backwards-compatible behavior.

### Description
- Added a new default-enabled config option `settings.mountable-skeleton-horses` to `BetterHorses/src/main/resources/config.yml` and documented it in `README.md`.
- Updated `HorseSpawnListener` (`BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseSpawnListener.java`) to call a new private helper `makeSkeletonHorseMountableIfEnabled(BetterHorses, AbstractHorse)` for every spawned `SkeletonHorse` instance.
- The helper checks `settings.mountable-skeleton-horses` and marks matching skeleton horses as tamed via `horse.setTamed(true)`, and logs the action using the plugin debug logger.
- Added the `org.bukkit.entity.SkeletonHorse` import and adjusted the early spawn handling so skeleton horses are made mountable even if not naturally spawned.

### Testing
- Ran `git diff --check` which completed without warnings.
- Attempted to run `./gradlew build`, but the build could not complete in the environment due to Gradle/Java incompatibility (environment Java version is newer than the Gradle setup), so compilation verification was blocked by the runtime; the failure was unrelated to the code change itself and reported as `Unsupported class file major version 69`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36987deab4832b88c9c0b4b033b52b)