### PR TITLE
Add toggleable sand slowness for mounted horses

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
@@ -277,6 +277,11 @@ public class BetterHorses extends JavaPlugin {
             debugLog("LISTENER", "REGISTER", true, "Registered MountedDamageBoostListener.");
         }
 
+        if (config.getBoolean("settings.sand-slowness.enabled", false)) {
+            pluginManager.registerEvents(new SandSlownessListener(), this);
+            debugLog("LISTENER", "REGISTER", true, "Registered SandSlownessListener.");
+        }
+
         boolean traitsEnabled = config.getBoolean("traits.enabled", true);
         if (!traitsEnabled) {
             debugLog("LISTENER", "REGISTER_TRAITS", false, "Trait listeners were skipped because traits are disabled.");

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/SandSlownessListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/SandSlownessListener.java
@@ -1,0 +1,46 @@
+package me.luisgamedev.betterhorses.listeners;
+
+import me.luisgamedev.betterhorses.BetterHorses;
+import me.luisgamedev.betterhorses.utils.SupportedMountType;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.AbstractHorse;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+public class SandSlownessListener implements Listener {
+
+    private static final Set<Material> SAND_BLOCKS = EnumSet.of(
+            Material.SAND,
+            Material.RED_SAND,
+            Material.SUSPICIOUS_SAND
+    );
+    private static final PotionEffect SAND_SLOWNESS = new PotionEffect(
+            PotionEffectType.SLOWNESS,
+            40,
+            0,
+            false,
+            false,
+            false
+    );
+
+    @EventHandler
+    public void onPlayerMove(PlayerMoveEvent event) {
+        if (!(event.getPlayer().getVehicle() instanceof AbstractHorse mount)) return;
+
+        SupportedMountType mountType = SupportedMountType.fromEntity(mount).orElse(null);
+        if (mountType == null || mountType == SupportedMountType.CAMEL) return;
+        if (!mountType.isEnabled(BetterHorses.getInstance().getConfig())) return;
+
+        Block blockBelowMount = mount.getLocation().subtract(0, 0.1, 0).getBlock();
+        if (!SAND_BLOCKS.contains(blockBelowMount.getType())) return;
+
+        mount.addPotionEffect(SAND_SLOWNESS);
+    }
+}

--- a/BetterHorses/src/main/resources/config.yml
+++ b/BetterHorses/src/main/resources/config.yml
@@ -121,6 +121,11 @@ settings:
     enabled: false
     percentage: 25.0 # 25% more damage while mounted
 
+  # Applies Slowness I to mounted horses while they walk on sand blocks.
+  # This affects horses, skeleton horses, and zombie horses, but not camels.
+  sand-slowness:
+    enabled: false
+
   # Traited horses will have particles around them, disabling this will result in slightly better performance
   trait-particle-indicator: true
 


### PR DESCRIPTION
### Motivation
- Provide an optional gameplay penalty where mounted horses slow down while walking on sand to simulate sand movement difficulty. 
- Make the feature toggleable and disabled by default so servers can opt in without breaking existing behavior. 
- Exclude camels and unsupported mount types from the effect so mount-specific behavior is preserved. 

### Description
- Added a new listener `SandSlownessListener` that listens to `PlayerMoveEvent`, checks the rider's mount via `SupportedMountType.fromEntity`, ignores camels and disabled mount types, detects sand blocks (`SAND`, `RED_SAND`, `SUSPICIOUS_SAND`) beneath the mount, and applies a `SLOWNESS` effect (`duration=40` ticks, amplifier `0`).
- Registered the listener conditionally in `BetterHorses.registerListeners()` when `settings.sand-slowness.enabled` is `true` so the feature is only active when configured. 
- Added a disabled-by-default config toggle `settings.sand-slowness.enabled: false` to `config.yml` with explanatory comments. 

### Testing
- Ran `git diff --check`, which reported no whitespace or diff-check issues. 
- Attempted a full build with `JAVA_HOME=/root/.local/share/mise/installs/java/21.0.2 ./gradlew build`, which failed due to remote Maven repositories returning `403 Forbidden` while resolving dependencies. 
- Attempted an offline compile with `./gradlew --offline compileJava`, which failed because the required dependencies were not available in the local cache.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36a21f2780832bb0066eb1fd245e17)