### PR TITLE
Make horse item display name configurable via language.yml

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
@@ -124,7 +124,7 @@ public class BetterHorsesAPI {
         );
 
         meta.setLore(lore);
-        meta.setDisplayName(name);
+        meta.setDisplayName(formatHorseItemName(lang, name, genderSymbol));
         item.setItemMeta(meta);
 
         if(targetInventory != null) {
@@ -338,7 +338,7 @@ public class BetterHorsesAPI {
 
         itemData.set(genderKey, PersistentDataType.STRING, gender);
         String name = horse.getCustomName() != null ? horse.getCustomName() : mountType.getDisplayName(lang);
-        meta.setDisplayName(ChatColor.GOLD + name + " " + genderSymbol);
+        meta.setDisplayName(formatHorseItemName(lang, name, genderSymbol));
 
         List<String> lore = buildHorseLore(
                 plugin.getConfig(),
@@ -393,6 +393,11 @@ public class BetterHorsesAPI {
 
         item.setItemMeta(meta);
         return item;
+    }
+
+    private static String formatHorseItemName(LanguageManager lang, @Nullable String name, String genderSymbol) {
+        String displayName = name == null || name.isBlank() ? lang.getRaw("messages.horse") : name;
+        return lang.getFormattedRaw("messages.horse-item-name", "%name%", displayName, "%gender%", genderSymbol);
     }
 
     private static @Nullable ItemStack restoreArmorItem(String armorMaterial, @Nullable String serializedArmor) {

--- a/BetterHorses/src/main/resources/language.yml
+++ b/BetterHorses/src/main/resources/language.yml
@@ -3,6 +3,7 @@ prefix: "&7[&6BetterHorses&7] "
 messages:
   horse: "Horse"
   camel: "Camel"
+  horse-item-name: "<gold>%name% %gender%</gold>"
   lore-gender: "Gender: %value%"
   insufficient-permission: "You don't have permission to use %command%."
   horse-usage: "Usage: /horse <spawn|despawn|neuter|reload|info*>"


### PR DESCRIPTION
### Motivation
- Allow the horse item display name (horse name + gender icon) to be formatted from the language file using MiniMessage and placeholders so server owners can customize color/formatting.

### Description
- Added a `messages.horse-item-name` entry to `BetterHorses/src/main/resources/language.yml` with a default MiniMessage value of `"<gold>%name% %gender%</gold>"`.
- Replaced direct `meta.setDisplayName(...)` calls in `BetterHorsesAPI` with a shared helper `formatHorseItemName(LanguageManager, String, String)` that resolves `%name%` and `%gender%` via `LanguageManager.getFormattedRaw` and uses `messages.horse` as a fallback when the horse name is missing.
- Updated both item creation and horse-to-item conversion paths to use the new helper so created and despawned/converted horse items share the configurable format.

### Testing
- Ran `git diff --check` and committed the changes successfully as `Add configurable horse item name format`.
- Attempted a Gradle build via `JAVA_HOME=/root/.local/share/mise/installs/java/21.0.2 ./gradlew build` but the build could not complete due to external Maven repositories returning HTTP 403 while resolving Paper/ProtocolLib/PlaceholderAPI dependencies, so compilation was not verified in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36a3474a7c832b8da35b72922dbc33)