### PR TITLE
Fix active trait cleanup on player logout

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
@@ -300,6 +300,11 @@ public class BetterHorses extends JavaPlugin {
             debugLog("LISTENER", "REGISTER", true, "Registered TraitActivationListener.");
         }
 
+        if (isAnyTraitEnabled("dashboost", "ghosthorse")) {
+            pluginManager.registerEvents(new TraitCleanupListener(), this);
+            debugLog("LISTENER", "REGISTER", true, "Registered TraitCleanupListener.");
+        }
+
         if (isAnyTraitEnabled("frosthooves", "featherhooves", "fireheart")) {
             pluginManager.registerEvents(new PassiveTraitListener(), this);
             debugLog("LISTENER", "REGISTER", true, "Registered PassiveTraitListener.");

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/TraitCleanupListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/TraitCleanupListener.java
@@ -1,0 +1,26 @@
+package me.luisgamedev.betterhorses.listeners;
+
+import me.luisgamedev.betterhorses.traits.TraitRegistry;
+import me.luisgamedev.betterhorses.utils.SupportedMountType;
+import org.bukkit.entity.AbstractHorse;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+public class TraitCleanupListener implements Listener {
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        Player player = event.getPlayer();
+        Entity vehicle = player.getVehicle();
+
+        if (!(vehicle instanceof AbstractHorse mount)) return;
+        if (!SupportedMountType.isSupported(mount)) return;
+
+        TraitRegistry.revertDashBoostIfActive(mount);
+        TraitRegistry.endGhostHorseIfActive(player, mount);
+    }
+}

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/traits/TraitRegistry.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/traits/TraitRegistry.java
@@ -21,10 +21,13 @@ import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.Vector;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 public class TraitRegistry {
@@ -33,6 +36,10 @@ public class TraitRegistry {
     static LanguageManager lang = BetterHorses.getInstance().getLang();
     static FileConfiguration config = BetterHorses.getInstance().getConfig();
     private static final Map<UUID, Double> dashBoostOriginalSpeeds = new HashMap<>();
+    private static final Map<UUID, BukkitTask> dashBoostTasks = new HashMap<>();
+    private static final Set<UUID> activeGhostHorsePlayers = new HashSet<>();
+    private static final Set<UUID> activeGhostHorseMounts = new HashSet<>();
+    private static final Map<UUID, BukkitTask> ghostHorseTasks = new HashMap<>();
 
     public static void activateHellmare(Player player, AbstractHorse horse) {
         if (!config.getBoolean("traits.hellmare.enabled")) return;
@@ -157,26 +164,25 @@ public class TraitRegistry {
 
         setCooldown(horse, key, config.getInt("traits.dashboost.cooldown", 30));
 
-        new BukkitRunnable() {
+        BukkitTask task = new BukkitRunnable() {
             @Override
             public void run() {
-                Double storedOriginal = dashBoostOriginalSpeeds.remove(horse.getUniqueId());
-                double revertSpeed = storedOriginal != null ? storedOriginal : originalSpeed;
-
-                if (horse.isValid()) {
-                    AttributeInstance speedAttr = horse.getAttribute(AttributeResolver.generic("MOVEMENT_SPEED"));
-                    if (speedAttr != null) {
-                        speedAttr.setBaseValue(revertSpeed);
-                    }
-                }
+                revertDashBoostIfActive(horse);
             }
         }.runTaskLater(BetterHorses.getInstance(), duration * 20L);
+        dashBoostTasks.put(horse.getUniqueId(), task);
     }
 
     public static void revertDashBoostIfActive(AbstractHorse horse) {
         if (horse == null) return;
 
-        Double storedOriginal = dashBoostOriginalSpeeds.remove(horse.getUniqueId());
+        UUID horseId = horse.getUniqueId();
+        BukkitTask task = dashBoostTasks.remove(horseId);
+        if (task != null) {
+            task.cancel();
+        }
+
+        Double storedOriginal = dashBoostOriginalSpeeds.remove(horseId);
         if (storedOriginal == null) return;
 
         if (!horse.isValid()) return;
@@ -208,19 +214,39 @@ public class TraitRegistry {
         horse.setInvisible(true);
         player.setInvisible(true);
         ArmorHider.hide(player, horse);
+        activeGhostHorsePlayers.add(player.getUniqueId());
+        activeGhostHorseMounts.add(horse.getUniqueId());
 
-        new BukkitRunnable() {
+        BukkitTask task = new BukkitRunnable() {
             @Override
             public void run() {
-                if (horse.isValid()) {
-                    player.setInvisible(false);
-                    horse.setInvisible(false);
-                    ArmorHider.show(player, horse);
-                }
+                endGhostHorseIfActive(player, horse);
             }
         }.runTaskLater(BetterHorses.getInstance(), duration * 20L);
+        ghostHorseTasks.put(horse.getUniqueId(), task);
 
         setCooldown(horse, key, config.getInt("traits.ghosthorse.cooldown", 30));
+    }
+
+    public static void endGhostHorseIfActive(Player player, AbstractHorse horse) {
+        if (player == null || horse == null) return;
+
+        UUID horseId = horse.getUniqueId();
+        UUID playerId = player.getUniqueId();
+        boolean horseWasActive = activeGhostHorseMounts.remove(horseId);
+        boolean playerWasActive = activeGhostHorsePlayers.remove(playerId);
+        if (!horseWasActive && !playerWasActive) return;
+
+        BukkitTask task = ghostHorseTasks.remove(horseId);
+        if (task != null) {
+            task.cancel();
+        }
+
+        player.setInvisible(false);
+        if (horse.isValid()) {
+            horse.setInvisible(false);
+            ArmorHider.show(player, horse);
+        }
     }
 
     public static void activateSkyburst(Player player, AbstractHorse horse) {


### PR DESCRIPTION
### Motivation
- Prevent dashboost and ghosthorse trait effects (speed bonus, invisibility, armor hiding) from persisting when a player logs out while the trait is active.
- Ensure trait state is ended immediately on logout so the server doesn't persist modified entity properties.

### Description
- Added a `TraitCleanupListener` listening for `PlayerQuitEvent` that calls cleanup hooks for mounted horses when a rider logs out using `TraitCleanupListener` and registered it when `dashboost` or `ghosthorse` are enabled.
- Track scheduled revert tasks and active state for dashboost and ghosthorse via `dashBoostTasks`, `ghostHorseTasks`, `activeGhostHorsePlayers`, and `activeGhostHorseMounts` in `TraitRegistry`.
- Exposed and implemented `revertDashBoostIfActive` to cancel pending dash revert tasks and restore the horse `MOVEMENT_SPEED` immediately and `endGhostHorseIfActive` to cancel pending ghost tasks and restore player/horse visibility and armor immediately.
- Updated `activateDashBoost` and `activateGhostHorse` to record their scheduled tasks and active sets so logout cleanup can reliably cancel scheduled expiration and restore state.

### Testing
- Ran `git diff --check` which completed successfully to validate formatting and basic diffs.
- Attempted `./gradlew build` which could not complete in this environment due to a Java/Gradle toolchain mismatch (build failed because the environment lacks the Java 21 toolchain required by the project).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36a7a31410832bb3c5fa1c706889ba)