### PR TITLE
Fix first-start config loading

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
@@ -37,6 +37,8 @@ public class BetterHorses extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        instance = this;
+        initializeConfigurationFiles();
         debugLog("PLUGIN", "ENABLE_START", true, "Starting BetterHorses plugin bootstrap.");
         if (getServer().getPluginManager().getPlugin("ProtocolLib") != null) {
             protocolLibAvailable = true;
@@ -48,10 +50,6 @@ public class BetterHorses extends JavaPlugin {
                     "Running BetterHorses without ProtocolLib is no problem, but will result in some features being disabled."
             );
         }
-        instance = this;
-        saveDefaultConfig();
-        updateYamlWithMissingSections("config.yml", false);
-        updateYamlWithMissingSections("language.yml", true);
         languageManager = new LanguageManager(this);
 
         registerListeners();
@@ -82,6 +80,14 @@ public class BetterHorses extends JavaPlugin {
 
     public LanguageManager getLang() {
         return languageManager;
+    }
+
+    private void initializeConfigurationFiles() {
+        saveDefaultConfig();
+        reloadConfig();
+        updateYamlWithMissingSections("config.yml", false);
+        updateYamlWithMissingSections("language.yml", true);
+        reloadConfig();
     }
 
     public void reloadPluginConfiguration() {


### PR DESCRIPTION
### Motivation
- Ensure the plugin recognizes the generated `config.yml` on first startup instead of reading a stale in-memory config created before the file was written.
- Avoid startup ordering where listeners, command aliases, or debug logging read configuration values before the default config has been persisted and reloaded.

### Description
- Move `instance = this` and configuration initialization to the very start of `onEnable()` so configuration is prepared before any config reads occur.
- Add a new `initializeConfigurationFiles()` method that runs `saveDefaultConfig()`, `reloadConfig()`, `updateYamlWithMissingSections("config.yml", false)`, `updateYamlWithMissingSections("language.yml", true)`, and `reloadConfig()` to ensure defaults are written and loaded into memory.
- Remove the previous early calls that relied on an uninitialized in-memory config so listeners/commands now see the actual saved config values.
- Changes are in `BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java`.

### Testing
- Attempted `./gradlew test`, but it failed due to local Java/Gradle compatibility with error `Unsupported class file major version 69` so unit tests could not be executed locally.
- Attempted `mvn -q -pl BetterHorses test`, but the project uses Gradle so Maven could not run tests for this module.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36aa67aca8832b9c9a5e48b43788e6)