### PR TITLE
Fix horsecreate MiniMessage legacy formatting

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/CustomHorseCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/CustomHorseCommand.java
@@ -47,7 +47,7 @@ public class CustomHorseCommand implements CommandExecutor {
             double speed = Double.parseDouble(args[1]);
             double jump = Double.parseDouble(args[2]);
             String gender = args.length >= 4 ? args[3].toLowerCase() : (Math.random() < 0.5 ? "male" : "female");
-            String name = args.length >= 5 ? "§6" + args[4] : "§6Horse";
+            String name = args.length >= 5 ? args[4] : lang.getRaw("messages.horse");
             String trait = args.length >= 6 ? args[5].toLowerCase() : null;
             int growthStage = args.length >= 7 ? Integer.parseInt(args[6]) : 10;
             String mountTypeArg = args.length >= 8 ? args[7] : null;

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/language/LanguageManager.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/language/LanguageManager.java
@@ -140,7 +140,7 @@ public class LanguageManager {
         StringBuilder converted = new StringBuilder(message.length());
         for (int i = 0; i < message.length(); i++) {
             char current = message.charAt(i);
-            if (current == '&' && i + 1 < message.length()) {
+            if ((current == '&' || current == '§') && i + 1 < message.length()) {
                 char code = Character.toLowerCase(message.charAt(i + 1));
                 if (code == 'r') {
                     converted.append("<reset>");


### PR DESCRIPTION
### Motivation

- Prevent a `MiniMessage` parsing exception caused by legacy section-sign color codes (`§`) in horse names and messages, which occurred because the command injected `§6` into the name and the language converter only handled ampersand (`&`).

### Description

- Stop prefixing custom names with a section-sign color code by changing `/horsecreate` to use the raw provided name or the language default via `lang.getRaw("messages.horse")` in `CustomHorseCommand.java`.
- Extend legacy formatting conversion to treat both `&` and `§` as legacy formatting prefixes in `LanguageManager.convertLegacyFormatting`, so both are translated into MiniMessage tags before deserialization.
- Changes applied to `BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/CustomHorseCommand.java` and `BetterHorses/src/main/java/me/luisgamedev/betterhorses/language/LanguageManager.java`.

### Testing

- Ran `git diff --check` which produced no issues and passed. 
- Attempted to run `./BetterHorses/gradlew -p BetterHorses build` but the build could not complete in this environment due to Gradle/Groovy not supporting the active Java class file version (`Unsupported class file major version 69`), so artifact build verification is blocked here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36ac3d4428832ba3e7e92843682303)