### PR TITLE
Enable sand slowness visibility and increase to Slowness II

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/SandSlownessListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/SandSlownessListener.java
@@ -24,10 +24,10 @@ public class SandSlownessListener implements Listener {
     private static final PotionEffect SAND_SLOWNESS = new PotionEffect(
             PotionEffectType.SLOWNESS,
             40,
-            0,
+            1,
             false,
-            false,
-            false
+            true,
+            true
     );
 
     @EventHandler

--- a/BetterHorses/src/main/resources/config.yml
+++ b/BetterHorses/src/main/resources/config.yml
@@ -121,7 +121,7 @@ settings:
     enabled: false
     percentage: 25.0 # 25% more damage while mounted
 
-  # Applies Slowness I to mounted horses while they walk on sand blocks.
+  # Applies Slowness II to mounted horses while they walk on sand blocks.
   # This affects all supported mount types except camels.
   sand-slowness:
     enabled: false


### PR DESCRIPTION
### Motivation
- Ensure the horse sand speed penalty displays a visible slowness effect and increase its strength from Slowness I to Slowness II.

### Description
- Changed the sand slowness `PotionEffect` to use amplifier `1` (Slowness II) and enabled particles and icon visibility by updating the `PotionEffect` constructor in `BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/SandSlownessListener.java`, and updated the related comment in `BetterHorses/src/main/resources/config.yml` to state Slowness II.

### Testing
- Ran `git diff --check` which passed, and attempted `./gradlew build` which failed in this environment due to a Java/Gradle runtime mismatch producing `Unsupported class file major version 69`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36b1eb6aa0832b8539574fc5ce90ee)