### PR TITLE
Resolve language placeholders for action-triggering player

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
@@ -50,7 +50,7 @@ public class BetterHorsesAPI {
         plugin.debugLog("API_CREATE_ITEM", "START", true, "Creating horse item health=" + health + ", speed=" + speed + ", jump=" + jump + ".");
         SupportedMountType targetMountType = mountType == null ? SupportedMountType.HORSE : mountType;
 
-        String genderSymbol = gender.equals("male") ? lang.getRaw("messages.gender-male") : gender.equals("female") ? lang.getRaw("messages.gender-female") : "?";
+        String genderSymbol = gender.equals("male") ? lang.getRaw(owner, "messages.gender-male") : gender.equals("female") ? lang.getRaw(owner, "messages.gender-female") : "?";
 
         String materialName = plugin.getConfig().getString("settings.horse-item", "SADDLE");
         Material material = Material.getMaterial(materialName.toUpperCase());
@@ -112,6 +112,7 @@ public class BetterHorsesAPI {
         List<String> lore = buildHorseLore(
                 config,
                 lang,
+                owner,
                 data,
                 genderSymbol,
                 health,
@@ -124,7 +125,7 @@ public class BetterHorsesAPI {
         );
 
         meta.setLore(lore);
-        meta.setDisplayName(formatHorseItemName(lang, name, genderSymbol));
+        meta.setDisplayName(formatHorseItemName(lang, owner, name, genderSymbol));
         item.setItemMeta(meta);
 
         if(targetInventory != null) {
@@ -314,7 +315,7 @@ public class BetterHorsesAPI {
             growthStage = 10;
         }
 
-        String genderSymbol = gender.equalsIgnoreCase("male") ? lang.getRaw("messages.gender-male") : gender.equalsIgnoreCase("female") ? lang.getRaw("messages.gender-female") : "?";
+        String genderSymbol = gender.equalsIgnoreCase("male") ? lang.getRaw(ownerOverride, "messages.gender-male") : gender.equalsIgnoreCase("female") ? lang.getRaw(ownerOverride, "messages.gender-female") : "?";
 
         TraitRegistry.revertDashBoostIfActive(horse);
         TrainingManager.ensureBaseStats(horse);
@@ -337,12 +338,13 @@ public class BetterHorsesAPI {
         PersistentDataContainer itemData = meta.getPersistentDataContainer();
 
         itemData.set(genderKey, PersistentDataType.STRING, gender);
-        String name = horse.getCustomName() != null ? horse.getCustomName() : mountType.getDisplayName(lang);
-        meta.setDisplayName(formatHorseItemName(lang, name, genderSymbol));
+        String name = horse.getCustomName() != null ? horse.getCustomName() : mountType.getDisplayName(lang, ownerOverride);
+        meta.setDisplayName(formatHorseItemName(lang, ownerOverride, name, genderSymbol));
 
         List<String> lore = buildHorseLore(
                 plugin.getConfig(),
                 lang,
+                ownerOverride,
                 data,
                 genderSymbol,
                 currentHealth,
@@ -395,9 +397,9 @@ public class BetterHorsesAPI {
         return item;
     }
 
-    private static String formatHorseItemName(LanguageManager lang, @Nullable String name, String genderSymbol) {
-        String displayName = name == null || name.isBlank() ? lang.getRaw("messages.horse") : name;
-        return lang.getFormattedRaw("messages.horse-item-name", "%name%", displayName, "%gender%", genderSymbol);
+    private static String formatHorseItemName(LanguageManager lang, @Nullable Player player, @Nullable String name, String genderSymbol) {
+        String displayName = name == null || name.isBlank() ? lang.getRaw(player, "messages.horse") : name;
+        return lang.getFormattedRaw(player, "messages.horse-item-name", "%name%", displayName, "%gender%", genderSymbol);
     }
 
     private static @Nullable ItemStack restoreArmorItem(String armorMaterial, @Nullable String serializedArmor) {
@@ -418,6 +420,7 @@ public class BetterHorsesAPI {
     private static List<String> buildHorseLore(
             FileConfiguration config,
             LanguageManager lang,
+            @Nullable Player player,
             PersistentDataContainer data,
             String genderSymbol,
             double currentHealth,
@@ -438,6 +441,7 @@ public class BetterHorsesAPI {
                 layout,
                 lore,
                 lang,
+                player,
                 data,
                 genderSymbol,
                 currentHealth,
@@ -480,6 +484,7 @@ public class BetterHorsesAPI {
             Object node,
             List<String> lore,
             LanguageManager lang,
+            @Nullable Player player,
             PersistentDataContainer data,
             String genderSymbol,
             double currentHealth,
@@ -492,7 +497,7 @@ public class BetterHorsesAPI {
     ) {
         if (node instanceof List<?> list) {
             for (Object child : list) {
-                appendLoreLayoutNodes(child, lore, lang, data, genderSymbol, currentHealth, maxHealth, speed, jump, growth, trait, isNeutered);
+                appendLoreLayoutNodes(child, lore, lang, player, data, genderSymbol, currentHealth, maxHealth, speed, jump, growth, trait, isNeutered);
             }
             return;
         }
@@ -500,21 +505,21 @@ public class BetterHorsesAPI {
         if (node instanceof Map<?, ?> map) {
             for (Map.Entry<?, ?> entry : map.entrySet()) {
                 String rawPart = String.valueOf(entry.getKey());
-                List<String> sectionLines = resolveHorseLoreLines(rawPart, lang, data, genderSymbol, currentHealth, maxHealth, speed, jump, growth, trait, isNeutered);
+                List<String> sectionLines = resolveHorseLoreLines(rawPart, lang, player, data, genderSymbol, currentHealth, maxHealth, speed, jump, growth, trait, isNeutered);
                 boolean parentIsGroup = sectionLines.isEmpty() && !isDirectLoreLineToken(rawPart);
                 if (!sectionLines.isEmpty()) {
                     lore.addAll(sectionLines);
                 }
 
                 if (!sectionLines.isEmpty() || parentIsGroup) {
-                    appendLoreLayoutNodes(entry.getValue(), lore, lang, data, genderSymbol, currentHealth, maxHealth, speed, jump, growth, trait, isNeutered);
+                    appendLoreLayoutNodes(entry.getValue(), lore, lang, player, data, genderSymbol, currentHealth, maxHealth, speed, jump, growth, trait, isNeutered);
                 }
             }
             return;
         }
 
         if (node instanceof String rawPart) {
-            lore.addAll(resolveHorseLoreLines(rawPart, lang, data, genderSymbol, currentHealth, maxHealth, speed, jump, growth, trait, isNeutered));
+            lore.addAll(resolveHorseLoreLines(rawPart, lang, player, data, genderSymbol, currentHealth, maxHealth, speed, jump, growth, trait, isNeutered));
         }
     }
 
@@ -529,6 +534,7 @@ public class BetterHorsesAPI {
     private static List<String> resolveHorseLoreLines(
             String rawPart,
             LanguageManager lang,
+            @Nullable Player player,
             PersistentDataContainer data,
             String genderSymbol,
             double currentHealth,
@@ -543,19 +549,19 @@ public class BetterHorsesAPI {
         List<String> sectionLines = new ArrayList<>();
 
         switch (part) {
-            case "gender" -> sectionLines.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-gender", "%value%", genderSymbol));
-            case "health" -> sectionLines.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-health", "%value%", String.format("%.2f", currentHealth), "%max%", String.format("%.2f", maxHealth)));
-            case "speed" -> sectionLines.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-speed", "%value%", String.format("%.4f", speed)));
-            case "jump" -> sectionLines.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-jump", "%value%", String.format("%.4f", jump)));
-            case "growth" -> sectionLines.add(ChatColor.GRAY + lang.getFormattedRaw("messages.lore-growth", "%value%", String.format("%d", growth)));
+            case "gender" -> sectionLines.add(ChatColor.GRAY + lang.getFormattedRaw(player, "messages.lore-gender", "%value%", genderSymbol));
+            case "health" -> sectionLines.add(ChatColor.GRAY + lang.getFormattedRaw(player, "messages.lore-health", "%value%", String.format("%.2f", currentHealth), "%max%", String.format("%.2f", maxHealth)));
+            case "speed" -> sectionLines.add(ChatColor.GRAY + lang.getFormattedRaw(player, "messages.lore-speed", "%value%", String.format("%.4f", speed)));
+            case "jump" -> sectionLines.add(ChatColor.GRAY + lang.getFormattedRaw(player, "messages.lore-jump", "%value%", String.format("%.4f", jump)));
+            case "growth" -> sectionLines.add(ChatColor.GRAY + lang.getFormattedRaw(player, "messages.lore-growth", "%value%", String.format("%d", growth)));
             case "trait" -> {
                 if (trait != null && !trait.isBlank()) {
-                    sectionLines.add(ChatColor.GOLD + lang.getFormattedRaw("messages.trait-line", "%trait%", formatTraitName(trait)));
+                    sectionLines.add(ChatColor.GOLD + lang.getFormattedRaw(player, "messages.trait-line", "%trait%", formatTraitName(trait)));
                 }
             }
             case "neutered" -> {
                 if (isNeutered) {
-                    sectionLines.add(ChatColor.DARK_GRAY + lang.getRaw("messages.lore-neutered"));
+                    sectionLines.add(ChatColor.DARK_GRAY + lang.getRaw(player, "messages.lore-neutered"));
                 }
             }
             case "training" -> {

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/CustomHorseCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/CustomHorseCommand.java
@@ -31,13 +31,13 @@ public class CustomHorseCommand implements CommandExecutor {
         }
 
         if (!player.hasPermission("betterhorses.create")) {
-            player.sendMessage(lang.getFormatted("messages.insufficient-permission", "%command%", "/horsecreate"));
+            player.sendMessage(lang.getFormatted(player, "messages.insufficient-permission", "%command%", "/horsecreate"));
             plugin.debugLog("HORSE_CREATE", "PERMISSION", false, "Player " + player.getName() + " lacks betterhorses.create.");
             return true;
         }
 
         if (args.length < 3) {
-            player.sendMessage(lang.get("messages.horsecreate-usage"));
+            player.sendMessage(lang.get(player, "messages.horsecreate-usage"));
             plugin.debugLog("HORSE_CREATE", "USAGE", false, "Player " + player.getName() + " provided too few arguments.");
             return true;
         }
@@ -47,7 +47,7 @@ public class CustomHorseCommand implements CommandExecutor {
             double speed = Double.parseDouble(args[1]);
             double jump = Double.parseDouble(args[2]);
             String gender = args.length >= 4 ? args[3].toLowerCase() : (Math.random() < 0.5 ? "male" : "female");
-            String name = args.length >= 5 ? args[4] : lang.getRaw("messages.horse");
+            String name = args.length >= 5 ? args[4] : lang.getRaw(player, "messages.horse");
             String trait = args.length >= 6 ? args[5].toLowerCase() : null;
             int growthStage = args.length >= 7 ? Integer.parseInt(args[6]) : 10;
             String mountTypeArg = args.length >= 8 ? args[7] : null;
@@ -57,13 +57,13 @@ public class CustomHorseCommand implements CommandExecutor {
 
             SupportedMountType mountType = mountTypeArg == null ? SupportedMountType.HORSE : SupportedMountType.fromUserInput(mountTypeArg).orElse(null);
             if (mountType == null) {
-                player.sendMessage(lang.getFormatted("messages.invalid-mount-type", "%types%", getEnabledMountTypes(config)));
+                player.sendMessage(lang.getFormatted(player, "messages.invalid-mount-type", "%types%", getEnabledMountTypes(config)));
                 plugin.debugLog("HORSE_CREATE", "MOUNT_TYPE", false, "Invalid mount type input: " + mountTypeArg);
                 return true;
             }
 
             if (!mountType.isEnabled(config)) {
-                player.sendMessage(lang.get("messages.mount-type-disabled"));
+                player.sendMessage(lang.get(player, "messages.mount-type-disabled"));
                 plugin.debugLog("HORSE_CREATE", "MOUNT_TYPE", false, "Disabled mount type requested: " + mountType.getEntityType());
                 return true;
             }
@@ -72,14 +72,14 @@ public class CustomHorseCommand implements CommandExecutor {
 
             if (trait != null && !trait.equalsIgnoreCase("none")) {
                 if (!config.getBoolean("traits.enabled", false)) {
-                    player.sendMessage(lang.get("messages.traits-disabled"));
+                    player.sendMessage(lang.get(player, "messages.traits-disabled"));
                     plugin.debugLog("HORSE_CREATE", "TRAIT", false, "Trait requested while traits are disabled.");
                     return true;
                 }
 
                 ConfigurationSection traitSection = config.getConfigurationSection("traits." + trait);
                 if (traitSection == null || !traitSection.getBoolean("enabled", false)) {
-                    player.sendMessage(lang.get("messages.traits-error"));
+                    player.sendMessage(lang.get(player, "messages.traits-error"));
                     plugin.debugLog("HORSE_CREATE", "TRAIT", false, "Invalid or disabled trait requested: " + trait);
                     return true;
                 }
@@ -93,7 +93,7 @@ public class CustomHorseCommand implements CommandExecutor {
             return true;
 
         } catch (NumberFormatException e) {
-            player.sendMessage(lang.get("messages.invalid-number-format"));
+            player.sendMessage(lang.get(player, "messages.invalid-number-format"));
             plugin.debugLog("HORSE_CREATE", "PARSE", false, "Invalid numeric argument from " + player.getName() + ": " + e.getMessage());
             return true;
         }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/DespawnCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/DespawnCommand.java
@@ -21,7 +21,7 @@ public class DespawnCommand {
         plugin.debugLog("HORSE_DESPAWN", "START", true, "Player " + player.getName() + " requested despawn.");
 
         if (!(player.getVehicle() instanceof AbstractHorse horse)) {
-            player.sendMessage(lang.get("messages.invalid-vehicle"));
+            player.sendMessage(lang.get(player, "messages.invalid-vehicle"));
             plugin.debugLog("HORSE_DESPAWN", "VALIDATION", false, "Player " + player.getName() + " is not riding a supported mount.");
             return true;
         }
@@ -31,12 +31,12 @@ public class DespawnCommand {
                 .orElse(null);
 
         if (mountType == null) {
-            player.sendMessage(lang.get("messages.invalid-vehicle"));
+            player.sendMessage(lang.get(player, "messages.invalid-vehicle"));
             plugin.debugLog("HORSE_DESPAWN", "MOUNT_TYPE", false, "Mount type disabled or unsupported for player " + player.getName() + ".");
             return true;
         }
 
-        String mountName = mountType.getDisplayName(lang);
+        String mountName = mountType.getDisplayName(lang, player);
 
         PersistentDataContainer data = horse.getPersistentDataContainer();
         String storedOwner = data.get(BetterHorseKeys.OWNER, PersistentDataType.STRING);
@@ -49,14 +49,14 @@ public class DespawnCommand {
         }
 
         if (ownershipRequired && !isOwner) {
-            player.sendMessage(lang.getFormatted("messages.not-horse-owner", "%mount%", mountName));
+            player.sendMessage(lang.getFormatted(player, "messages.not-horse-owner", "%mount%", mountName));
             plugin.debugLog("HORSE_DESPAWN", "OWNERSHIP", false, "Player " + player.getName() + " is not owner of " + horse.getUniqueId() + ".");
             return true;
         }
 
         ItemStack item = BetterHorsesAPI.toItem(horse, player);
         if (item == null) {
-            player.sendMessage(lang.get("messages.cant-despawn"));
+            player.sendMessage(lang.get(player, "messages.cant-despawn"));
             plugin.debugLog("HORSE_DESPAWN", "ITEM", false, "Failed converting horse to item for " + horse.getUniqueId() + ".");
             return true;
         }
@@ -71,7 +71,7 @@ public class DespawnCommand {
         horse.remove();
 
         if (horse.isValid()) {
-            player.sendMessage(lang.get("messages.cant-despawn"));
+            player.sendMessage(lang.get(player, "messages.cant-despawn"));
             plugin.debugLog("HORSE_DESPAWN", "REMOVE", false, "Horse remained valid after remove call: " + horse.getUniqueId());
             return true;
         }
@@ -86,7 +86,7 @@ public class DespawnCommand {
             player.getInventory().addItem(item);
         }
 
-        player.sendMessage(lang.getFormatted("messages.horse-despawned", "%mount%", mountName));
+        player.sendMessage(lang.getFormatted(player, "messages.horse-despawned", "%mount%", mountName));
         plugin.debugLog("HORSE_DESPAWN", "COMPLETE", true, "Player " + player.getName() + " despawned " + mountName + ".");
         return true;
     }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseCommand.java
@@ -5,6 +5,7 @@ import me.luisgamedev.betterhorses.language.LanguageManager;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 
 public class HorseCommand implements CommandExecutor {
@@ -13,9 +14,10 @@ public class HorseCommand implements CommandExecutor {
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         BetterHorses plugin = BetterHorses.getInstance();
         LanguageManager lang = plugin.getLang();
+        OfflinePlayer audience = sender instanceof Player senderPlayer ? senderPlayer : null;
 
         if (args.length == 0) {
-            sender.sendMessage(lang.get("messages.horse-usage"));
+            sender.sendMessage(lang.get(audience, "messages.horse-usage"));
             return true;
         }
 
@@ -25,21 +27,21 @@ public class HorseCommand implements CommandExecutor {
 
         if (subcommand.equals("reload")) {
             if (!sender.hasPermission("betterhorses.reload")) {
-                sender.sendMessage(lang.getFormatted("messages.insufficient-permission", "%command%", "/horse reload"));
+                sender.sendMessage(lang.getFormatted(audience, "messages.insufficient-permission", "%command%", "/horse reload"));
                 plugin.debugLog("HORSE_COMMAND", "RELOAD_PERMISSION", false,
                         "Sender " + sender.getName() + " lacks betterhorses.reload");
                 return true;
             }
 
             plugin.reloadPluginConfiguration();
-            sender.sendMessage(lang.get("messages.config-reloaded"));
+            sender.sendMessage(lang.get(audience, "messages.config-reloaded"));
             plugin.debugLog("HORSE_COMMAND", "RELOAD", true,
                     "Configuration reloaded by " + sender.getName());
             return true;
         }
 
         if (!(sender instanceof Player player)) {
-            sender.sendMessage(lang.get("messages.only-players"));
+            sender.sendMessage(lang.get(audience, "messages.only-players"));
             plugin.debugLog("HORSE_COMMAND", "PLAYER_REQUIRED", false,
                     "Non-player sender tried subcommand " + subcommand);
             return true;
@@ -48,7 +50,7 @@ public class HorseCommand implements CommandExecutor {
         switch (subcommand) {
             case "spawn":
                 if (!player.hasPermission("betterhorses.base")) {
-                    player.sendMessage(lang.getFormatted("messages.insufficient-permission", "%command%", "/horse spawn"));
+                    player.sendMessage(lang.getFormatted(player, "messages.insufficient-permission", "%command%", "/horse spawn"));
                     plugin.debugLog("HORSE_COMMAND", "SPAWN_PERMISSION", false,
                             "Player " + player.getName() + " lacks betterhorses.base");
                     return true;
@@ -57,7 +59,7 @@ public class HorseCommand implements CommandExecutor {
 
             case "despawn":
                 if (!player.hasPermission("betterhorses.base")) {
-                    player.sendMessage(lang.getFormatted("messages.insufficient-permission", "%command%", "/horse despawn"));
+                    player.sendMessage(lang.getFormatted(player, "messages.insufficient-permission", "%command%", "/horse despawn"));
                     plugin.debugLog("HORSE_COMMAND", "DESPAWN_PERMISSION", false,
                             "Player " + player.getName() + " lacks betterhorses.base");
                     return true;
@@ -66,7 +68,7 @@ public class HorseCommand implements CommandExecutor {
 
             case "neuter":
                 if (!player.hasPermission("betterhorses.neuter")) {
-                    player.sendMessage(lang.getFormatted("messages.insufficient-permission", "%command%", "/horse neuter"));
+                    player.sendMessage(lang.getFormatted(player, "messages.insufficient-permission", "%command%", "/horse neuter"));
                     plugin.debugLog("HORSE_COMMAND", "NEUTER_PERMISSION", false,
                             "Player " + player.getName() + " lacks betterhorses.neuter");
                     return true;
@@ -75,7 +77,7 @@ public class HorseCommand implements CommandExecutor {
 
             case "info":
                 if (!plugin.isDebugModeEnabled()) {
-                    player.sendMessage(lang.get("messages.unknown-subcommand"));
+                    player.sendMessage(lang.get(player, "messages.unknown-subcommand"));
                     plugin.debugLog("HORSE_COMMAND", "INFO_DEBUG_DISABLED", false,
                             "Player " + player.getName() + " used /horse info while debug mode is disabled.");
                     return true;
@@ -83,7 +85,7 @@ public class HorseCommand implements CommandExecutor {
                 return HorseInfoCommand.handle(player);
 
             default:
-                player.sendMessage(lang.get("messages.unknown-subcommand"));
+                player.sendMessage(lang.get(player, "messages.unknown-subcommand"));
                 plugin.debugLog("HORSE_COMMAND", "UNKNOWN_SUBCOMMAND", false,
                         "Player " + player.getName() + " used unknown subcommand: " + subcommand);
                 return true;

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseNeuterCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseNeuterCommand.java
@@ -22,7 +22,7 @@ public class HorseNeuterCommand {
         LanguageManager lang = BetterHorses.getInstance().getLang();
 
         if (!player.hasPermission("betterhorses.neuter")) {
-            player.sendMessage(lang.getFormatted("messages.insufficient-permission", "%command%", "/horse neuter"));
+            player.sendMessage(lang.getFormatted(player, "messages.insufficient-permission", "%command%", "/horse neuter"));
             BetterHorses.getInstance().debugLog("HORSE_NEUTER", "PERMISSION", false,
                     "Player " + player.getName() + " lacks betterhorses.neuter");
             return true;
@@ -33,7 +33,7 @@ public class HorseNeuterCommand {
         Material expected = Material.getMaterial(config.getString("settings.horse-item", "SADDLE").toUpperCase());
 
         if (expected == null || item == null || item.getType() != expected || !item.hasItemMeta()) {
-            player.sendMessage(lang.get("messages.invalid-item"));
+            player.sendMessage(lang.get(player, "messages.invalid-item"));
             BetterHorses.getInstance().debugLog("HORSE_NEUTER", "VALIDATION", false,
                     "Player " + player.getName() + " did not hold a valid horse item.");
             return true;
@@ -44,7 +44,7 @@ public class HorseNeuterCommand {
                 "Valid item detected for player " + player.getName());
 
         if (meta.getPersistentDataContainer().has(BetterHorseKeys.NEUTERED, PersistentDataType.BYTE)) {
-            player.sendMessage(lang.get("messages.already-castrated"));
+            player.sendMessage(lang.get(player, "messages.already-castrated"));
             BetterHorses.getInstance().debugLog("HORSE_NEUTER", "ALREADY_NEUTERED", false,
                     "Horse item is already neutered for player " + player.getName());
             return true;
@@ -64,12 +64,12 @@ public class HorseNeuterCommand {
         meta.getPersistentDataContainer().set(BetterHorseKeys.NEUTERED, PersistentDataType.BYTE, (byte) 1);
 
         List<String> lore = meta.hasLore() ? new ArrayList<>(meta.getLore()) : new ArrayList<>();
-        lore.add(ChatColor.DARK_GRAY + lang.getRaw("messages.lore-neutered"));
+        lore.add(ChatColor.DARK_GRAY + lang.getRaw(player, "messages.lore-neutered"));
         meta.setLore(lore);
 
         item.setItemMeta(meta);
         player.getInventory().setItemInMainHand(item);
-        player.sendMessage(lang.get("messages.successfully-castrated"));
+        player.sendMessage(lang.get(player, "messages.successfully-castrated"));
         BetterHorses.getInstance().debugLog("HORSE_NEUTER", "COMPLETE", true,
                 "Horse item neutered and written back to main hand for player " + player.getName());
         return true;

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/RespawnCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/RespawnCommand.java
@@ -26,7 +26,7 @@ public class RespawnCommand {
         if (expectedMaterial == null || !expectedMaterial.isItem()) expectedMaterial = Material.SADDLE;
 
         if (item == null || item.getType() != expectedMaterial || !item.hasItemMeta()) {
-            player.sendMessage(lang.get("messages.invalid-item"));
+            player.sendMessage(lang.get(player, "messages.invalid-item"));
             plugin.debugLog("HORSE_RESPAWN", "VALIDATION", false, "Invalid item used by " + player.getName() + ".");
             return true;
         }
@@ -37,24 +37,24 @@ public class RespawnCommand {
         String gender = item.getItemMeta().getPersistentDataContainer().get(BetterHorseKeys.GENDER, PersistentDataType.STRING);
         String mountTypeName = item.getItemMeta().getPersistentDataContainer().get(BetterHorseKeys.MOUNT_TYPE, PersistentDataType.STRING);
         SupportedMountType mountType = SupportedMountType.fromNameOrDefault(mountTypeName);
-        String mountName = mountType.getDisplayName(lang);
+        String mountName = mountType.getDisplayName(lang, player);
 
         if (health == null || speed == null || jump == null || gender == null || !mountType.isEnabled(BetterHorses.getInstance().getConfig())) {
-            player.sendMessage(lang.getFormatted("messages.invalid-horse-data", "%mount%", mountName));
+            player.sendMessage(lang.getFormatted(player, "messages.invalid-horse-data", "%mount%", mountName));
             plugin.debugLog("HORSE_RESPAWN", "DATA", false, "Invalid horse data for " + player.getName() + ".");
             return true;
         }
 
         AbstractHorse horse = BetterHorsesAPI.toHorse(item, player);
         if (horse == null) {
-            player.sendMessage(lang.get("messages.cant-spawn"));
+            player.sendMessage(lang.get(player, "messages.cant-spawn"));
             plugin.debugLog("HORSE_RESPAWN", "SPAWN", false, "Mount spawn failed for " + player.getName() + ".");
             return true;
         }
 
         item.setAmount(item.getAmount() - 1);
         BetterHorsesAPI.callSpawnEvent(horse, item, BetterHorseSpawnEvent.SpawnCause.ITEM);
-        player.sendMessage(lang.getFormatted("messages.horse-respawned", "%mount%", mountName));
+        player.sendMessage(lang.getFormatted(player, "messages.horse-respawned", "%mount%", mountName));
         plugin.debugLog("HORSE_RESPAWN", "COMPLETE", true, "Player " + player.getName() + " spawned " + mountName + ".");
         return true;
     }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/language/LanguageManager.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/language/LanguageManager.java
@@ -61,6 +61,10 @@ public class LanguageManager {
         return lang.getString(key, "&cMissing lang key: " + key);
     }
 
+    public String getRaw(OfflinePlayer player, String key) {
+        return parseToString(player, getRaw(key));
+    }
+
     public String get(String key) {
         return get(null, key);
     }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RightClickListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RightClickListener.java
@@ -55,16 +55,16 @@ public class RightClickListener implements Listener {
         String gender = meta.getPersistentDataContainer().get(BetterHorseKeys.GENDER, PersistentDataType.STRING);
         String mountTypeName = meta.getPersistentDataContainer().get(BetterHorseKeys.MOUNT_TYPE, PersistentDataType.STRING);
         SupportedMountType mountType = SupportedMountType.fromNameOrDefault(mountTypeName);
-        String mountName = mountType.getDisplayName(lang);
+        String mountName = mountType.getDisplayName(lang, player);
 
         if (health == null || speed == null || jump == null || gender == null || !mountType.isEnabled(config)) {
-            player.sendMessage(lang.getFormatted("messages.invalid-horse-data", "%mount%", mountName));
+            player.sendMessage(lang.getFormatted(player, "messages.invalid-horse-data", "%mount%", mountName));
             return;
         }
 
         AbstractHorse horse = BetterHorsesAPI.toHorse(item, player);
         if (horse == null) {
-            player.sendMessage(lang.get("messages.cant-spawn"));
+            player.sendMessage(lang.get(player, "messages.cant-spawn"));
             return;
         }
 
@@ -72,6 +72,6 @@ public class RightClickListener implements Listener {
         TrainingManager.recalculateAndApplyBonuses(horse);
 
         item.setAmount(item.getAmount() - 1);
-        player.sendMessage(lang.getFormatted("messages.horse-respawned", "%mount%", mountName));
+        player.sendMessage(lang.getFormatted(player, "messages.horse-respawned", "%mount%", mountName));
     }
 }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/traits/TraitRegistry.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/traits/TraitRegistry.java
@@ -52,7 +52,7 @@ public class TraitRegistry {
 
         int duration = config.getInt("traits.hellmare.duration", 10);
         int radius = config.getInt("traits.hellmare.radius", 1);
-        player.sendMessage(lang.get("traits.hellmare-message"));
+        player.sendMessage(lang.get(player, "traits.hellmare-message"));
 
         PotionEffect fireResist = new PotionEffect(PotionEffectType.FIRE_RESISTANCE, duration * 20, 1, false, false, false);
         player.addPotionEffect(fireResist);
@@ -160,7 +160,7 @@ public class TraitRegistry {
         double boostedSpeed = originalSpeed * 1.5;
 
         speedAttr.setBaseValue(boostedSpeed);
-        player.sendMessage(lang.get("traits.dashboost-message"));
+        player.sendMessage(lang.get(player, "traits.dashboost-message"));
 
         setCooldown(horse, key, config.getInt("traits.dashboost.cooldown", 30));
 
@@ -209,7 +209,7 @@ public class TraitRegistry {
         }
 
         int duration = config.getInt("traits.ghosthorse.duration", 5);
-        player.sendMessage(lang.get("traits.ghosthorse-message"));
+        player.sendMessage(lang.get(player, "traits.ghosthorse-message"));
 
         horse.setInvisible(true);
         player.setInvisible(true);
@@ -279,7 +279,7 @@ public class TraitRegistry {
         }
 
         int duration = config.getInt("traits.revenantcurse.duration", 5);
-        player.sendMessage(lang.get("traits.revenantcurse-message"));
+        player.sendMessage(lang.get(player, "traits.revenantcurse-message"));
 
         horse.getPersistentDataContainer().set(
                 new NamespacedKey(BetterHorses.getInstance(), "revenantcurse_active"),
@@ -318,7 +318,7 @@ public class TraitRegistry {
             }
         }
 
-        player.sendMessage(lang.get("traits.kickback-message"));
+        player.sendMessage(lang.get(player, "traits.kickback-message"));
         setCooldown(horse, key, config.getInt("traits.kickback.cooldown", 10));
     }
 
@@ -354,7 +354,7 @@ public class TraitRegistry {
         long now = System.currentTimeMillis();
         long until = cooldowns.get(horse.getUniqueId()).getOrDefault(key, 0L);
         double secondsLeft = (until - now) / 1000.0;
-        String name = lang.getRaw("traits." + key);
+        String name = lang.getRaw(player, "traits." + key);
 
         if (secondsLeft > 0) {
             CooldownDisplay.showCooldown(secondsLeft, fullCooldown, player, name);

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/CooldownDisplay.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/CooldownDisplay.java
@@ -58,7 +58,7 @@ public class CooldownDisplay {
         double maxDisplayDuration = 5.0;
         double displayTime = Math.min(maxDisplayDuration, remaining);
 
-        String title = lang.getFormattedRaw("messages.cooldown-message-bossbar", "%value%", abilityName);
+        String title = lang.getFormattedRaw(player, "messages.cooldown-message-bossbar", "%value%", abilityName);
 
         BossBar bar = Bukkit.createBossBar(
                 title,
@@ -115,6 +115,7 @@ public class CooldownDisplay {
                 }
 
                 String message = lang.getFormattedRaw(
+                        player,
                         "messages.cooldown-message-hotbar",
                         "%value%", abilityName,
                         "%remaining%", String.format(Locale.US, "%.1f", secondsLeft - secondsShown)

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/SupportedMountType.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/SupportedMountType.java
@@ -3,6 +3,7 @@ package me.luisgamedev.betterhorses.utils;
 import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.language.LanguageManager;
 import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.Camel;
@@ -50,7 +51,11 @@ public enum SupportedMountType {
     }
 
     public String getDisplayName(LanguageManager lang) {
-        return lang.getRaw("messages." + nameKey);
+        return getDisplayName(lang, null);
+    }
+
+    public String getDisplayName(LanguageManager lang, OfflinePlayer player) {
+        return lang.getRaw(player, "messages." + nameKey);
     }
 
     public AbstractHorse spawn(Location location) throws IllegalArgumentException {


### PR DESCRIPTION
### Motivation
- PlaceholderAPI placeholders in `language.yml` were not being evaluated for the player who triggered an action (despawn, neuter, spawn, trait activations, cooldowns, etc.), causing messages and item lore to show unresolved placeholders.
- Messages and horse item metadata need to be rendered in the context of the initiating player so PAPI values resolve to that player's data.

### Description
- Added a player-aware raw lookup `getRaw(OfflinePlayer player, String key)` and ensured parsing helpers accept an `OfflinePlayer` so PlaceholderAPI can be applied when present.
- Propagated the triggering player into language calls across commands/listeners/traits: replaced calls like `lang.get(...)`/`lang.getFormatted(...)`/`lang.getFormattedRaw(...)` with player-aware overloads where a player is available (commands, listeners, traits, cooldowns, etc.).
- Updated horse-item flows to carry the triggering/owner player into `BetterHorsesAPI` so display names, gender symbols, and lore lines are built with the player context, and added a `SupportedMountType.getDisplayName(LanguageManager, OfflinePlayer)` overload to support this.
- Updated `CooldownDisplay` and trait cooldown messaging to use player-aware formatting so bossbar/hotbar and trait messages resolve placeholders for the recipient.

### Testing
- Ran `git diff --check` to validate whitespace and local diffs and it passed.
- Attempted to run unit tests with `JAVA_HOME=/root/.local/share/mise/installs/java/21.0.2 ./gradlew test`, but the build was blocked because external Maven repositories returned HTTP 403 for Paper API / ProtocolLib / PlaceholderAPI dependencies, so automated tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36b1962d64832b90eeb7ce67e3cad1)