### PR TITLE
Fix horse trample targeting

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseTrampleListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseTrampleListener.java
@@ -8,6 +8,7 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.Vector;
@@ -68,6 +69,14 @@ public class HorseTrampleListener implements Listener {
 
     private void trample(AbstractHorse mount, FileConfiguration config, long now, long cooldownMillis) {
         Vector velocity = mount.getVelocity();
+        Player rider = mount.getPassengers().stream()
+                .filter(Player.class::isInstance)
+                .map(Player.class::cast)
+                .findFirst()
+                .orElse(null);
+        if (rider == null) {
+            return;
+        }
         double minimumSpeed = Math.max(
                 0.0,
                 config.getDouble("settings.horse-trample.minimum-speed", DEFAULT_MINIMUM_TRAMPLE_SPEED)
@@ -97,15 +106,15 @@ public class HorseTrampleListener implements Listener {
             if (!(nearby instanceof LivingEntity target) || target.equals(mount) || mount.getPassengers().contains(target)) {
                 continue;
             }
-            if (!isInTrampleHitbox(mount, target, velocity, horizontalRadius, verticalRadius, config)) {
+            if (!isInTrampleHitbox(mount, target, horizontalRadius, verticalRadius, config)) {
                 continue;
             }
             if (isOnCooldown(mount.getUniqueId(), target.getUniqueId(), now, cooldownMillis)) {
                 continue;
             }
 
-            target.damage(damage, mount);
-            applyKnockback(config, target, velocity);
+            target.damage(damage, rider);
+            applyKnockback(config, target, mount);
             setCooldown(mount.getUniqueId(), target.getUniqueId(), now);
         }
     }
@@ -113,7 +122,6 @@ public class HorseTrampleListener implements Listener {
     private boolean isInTrampleHitbox(
             AbstractHorse mount,
             LivingEntity target,
-            Vector velocity,
             double horizontalRadius,
             double verticalRadius,
             FileConfiguration config
@@ -132,10 +140,7 @@ public class HorseTrampleListener implements Listener {
             return true;
         }
 
-        Vector direction = velocity.clone().setY(0);
-        if (direction.lengthSquared() == 0) {
-            direction = mountLocation.getDirection().setY(0);
-        }
+        Vector direction = mountLocation.getDirection().setY(0);
         if (direction.lengthSquared() == 0) {
             return false;
         }
@@ -163,12 +168,12 @@ public class HorseTrampleListener implements Listener {
         trampleCooldowns.computeIfAbsent(mountId, ignored -> new HashMap<>()).put(targetId, now);
     }
 
-    private void applyKnockback(FileConfiguration config, LivingEntity target, Vector mountVelocity) {
+    private void applyKnockback(FileConfiguration config, LivingEntity target, AbstractHorse mount) {
         if (!config.getBoolean("settings.horse-trample.knockback.enabled", false)) {
             return;
         }
 
-        Vector direction = mountVelocity.clone().setY(0);
+        Vector direction = mount.getLocation().getDirection().setY(0);
         if (direction.lengthSquared() == 0) {
             return;
         }

--- a/BetterHorses/src/main/resources/config.yml
+++ b/BetterHorses/src/main/resources/config.yml
@@ -126,7 +126,7 @@ settings:
   sand-slowness:
     enabled: false
     
-  # Lets mounted horses trample entities they run into from the front.
+  # Lets mounted horses trample entities the mount is facing and runs into from the front.
   # Each mount tracks cooldowns per hit entity, so different horses can trample the same entity independently.
   horse-trample:
     damage: 2.0


### PR DESCRIPTION
### Motivation
- Trample currently damages the mount itself and uses movement direction to decide front hits, which causes incorrect damage attribution and misses cases where the horse is facing an entity but not moving directly toward it.
- The intent is for trampling to apply damage to entities the rider runs into while mounted, and to use the mount's facing direction for hit detection and knockback.

### Description
- Require a `Player` rider to be present before a mount can trample, returning early if no player is riding the mount.
- Attribute trample damage to the rider by calling `target.damage(damage, rider)` instead of using the `mount` as the damage source, preventing the horse from being damaged by its own trample.
- Use the mount's facing direction (`mount.getLocation().getDirection()`) for the front hitbox check instead of the mount's current velocity, so entities the horse faces are considered frontal targets.
- Apply knockback using the mount's facing direction and accept the `AbstractHorse mount` in `applyKnockback` for a consistent push direction.
- Clarified the `settings.horse-trample` config comment to indicate trampling is based on the mount's facing direction.

### Testing
- Attempted to run `./gradlew test` in the environment, but the Gradle build failed during build-script semantic analysis due to a Java/Gradle incompatibility (`Unsupported class file major version 69`), so automated tests could not complete.
- No unit or integration failures were observed at edit-time; changes are limited and localized to `HorseTrampleListener` and the config comment so runtime verification is recommended on a compatible Java/Gradle environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36b790972c832b95d0b106294291d6)