### PR TITLE
Fix horse trample cone protection checks

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseTrampleListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseTrampleListener.java
@@ -10,6 +10,8 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.Vector;
 
@@ -113,8 +115,13 @@ public class HorseTrampleListener implements Listener {
                 continue;
             }
 
-            target.damage(damage, rider);
-            applyKnockback(config, target, mount);
+            EntityDamageByEntityEvent damageEvent = callTrampleDamageEvent(rider, target, damage);
+            if (damageEvent.isCancelled()) {
+                continue;
+            }
+
+            applyTrampleDamage(target, damageEvent);
+            applyKnockback(config, target, rider);
             setCooldown(mount.getUniqueId(), target.getUniqueId(), now);
         }
     }
@@ -140,7 +147,16 @@ public class HorseTrampleListener implements Listener {
             return true;
         }
 
-        Vector direction = mountLocation.getDirection().setY(0);
+        Player rider = mount.getPassengers().stream()
+                .filter(Player.class::isInstance)
+                .map(Player.class::cast)
+                .findFirst()
+                .orElse(null);
+        if (rider == null) {
+            return false;
+        }
+
+        Vector direction = rider.getLocation().getDirection().setY(0);
         if (direction.lengthSquared() == 0) {
             return false;
         }
@@ -168,12 +184,33 @@ public class HorseTrampleListener implements Listener {
         trampleCooldowns.computeIfAbsent(mountId, ignored -> new HashMap<>()).put(targetId, now);
     }
 
-    private void applyKnockback(FileConfiguration config, LivingEntity target, AbstractHorse mount) {
+    private EntityDamageByEntityEvent callTrampleDamageEvent(Player rider, LivingEntity target, double damage) {
+        EntityDamageByEntityEvent damageEvent = new EntityDamageByEntityEvent(
+                rider,
+                target,
+                EntityDamageEvent.DamageCause.ENTITY_ATTACK,
+                damage
+        );
+        Bukkit.getPluginManager().callEvent(damageEvent);
+        return damageEvent;
+    }
+
+    private void applyTrampleDamage(LivingEntity target, EntityDamageByEntityEvent damageEvent) {
+        double finalDamage = Math.max(0.0, damageEvent.getFinalDamage());
+        if (finalDamage <= 0.0) {
+            return;
+        }
+
+        target.setLastDamageCause(damageEvent);
+        target.setHealth(Math.max(0.0, target.getHealth() - finalDamage));
+    }
+
+    private void applyKnockback(FileConfiguration config, LivingEntity target, Player rider) {
         if (!config.getBoolean("settings.horse-trample.knockback.enabled", false)) {
             return;
         }
 
-        Vector direction = mount.getLocation().getDirection().setY(0);
+        Vector direction = rider.getLocation().getDirection().setY(0);
         if (direction.lengthSquared() == 0) {
             return;
         }

--- a/BetterHorses/src/main/resources/config.yml
+++ b/BetterHorses/src/main/resources/config.yml
@@ -126,7 +126,8 @@ settings:
   sand-slowness:
     enabled: false
     
-  # Lets mounted horses trample entities the mount is facing and runs into from the front.
+  # Lets mounted horses trample entities inside a front cone based on the rider's looking direction.
+  # Trample damage fires a damage event first, so protection plugins can cancel both damage and knockback.
   # Each mount tracks cooldowns per hit entity, so different horses can trample the same entity independently.
   horse-trample:
     damage: 2.0
@@ -137,7 +138,7 @@ settings:
     hitbox:
       horizontal-radius: 1.15
       vertical-radius: 1.25
-      # -1.0 hits all directions, 0.0 hits the front half, higher values require targets to be more directly in front.
+      # -1.0 hits all directions, 0.0 hits the front half, higher values require targets to be more directly in front of the rider.
       front-dot-threshold: 0.0
     mount-types:
       horse:


### PR DESCRIPTION
### Motivation
- Make trample reliably affect entities in a cone relative to the rider's looking direction instead of the mount's facing direction.  
- Allow protection plugins to block trample damage and knockback by firing a cancellable damage event first.  
- Keep knockback direction aligned with the rider's look so stomp direction and push are consistent.

### Description
- Use the rider's look vector in `isInTrampleHitbox` to check the front cone instead of the mount's `Location.getDirection()`.  
- Fire an `EntityDamageByEntityEvent` via a new `callTrampleDamageEvent` helper and skip effects if the event is cancelled.  
- Apply damage through a new `applyTrampleDamage` helper that uses `damageEvent.getFinalDamage()` and updates the target's last damage cause and health.  
- Change `applyKnockback` to use the rider's look direction and only call it after the damage event is permitted, and update `config.yml` comments to document the new behavior.

### Testing
- Ran `git diff --check` successfully to ensure no whitespace or trivial diff issues.  
- Attempted `JAVA_HOME=$HOME/.local/share/mise/installs/java/21.0.2 PATH=$JAVA_HOME/bin:$PATH ./gradlew build` to build the project, which failed because remote repositories returned HTTP 403 for `compileOnly` artifacts so compilation could not be verified.  
- An earlier `./gradlew -q dependencies` run failed on the environment's Java version (unsupported class file major version) until the toolchain was switched to Java 21 for the subsequent build attempt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36ce0e36f8832b96e633327f911338)