### PR TITLE
Refactor horse trample to PlayerMoveEvent

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
@@ -269,9 +269,7 @@ public class BetterHorses extends JavaPlugin {
         }
       
         if (isHorseTrampleEnabled(config)) {
-            HorseTrampleListener horseTrampleListener = new HorseTrampleListener(this);
-            pluginManager.registerEvents(horseTrampleListener, this);
-            horseTrampleListener.start();
+            pluginManager.registerEvents(new HorseTrampleListener(this), this);
             debugLog("LISTENER", "REGISTER", true, "Registered HorseTrampleListener.");
         }
 

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseTrampleListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseTrampleListener.java
@@ -9,10 +9,11 @@ import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.util.Vector;
 
 import java.util.HashMap;
@@ -32,36 +33,37 @@ public class HorseTrampleListener implements Listener {
 
     private final BetterHorses plugin;
     private final Map<UUID, Map<UUID, Long>> trampleCooldowns = new HashMap<>();
-    private BukkitTask task;
 
     public HorseTrampleListener(BetterHorses plugin) {
         this.plugin = plugin;
     }
 
-    public void start() {
-        if (task != null) {
-            task.cancel();
+    @EventHandler(ignoreCancelled = true)
+    public void onPlayerMove(PlayerMoveEvent event) {
+        Player rider = event.getPlayer();
+        if (!(rider.getVehicle() instanceof AbstractHorse mount)) {
+            return;
         }
-        task = Bukkit.getScheduler().runTaskTimer(plugin, this::tick, 1L, 1L);
-    }
 
-    private void tick() {
         FileConfiguration config = plugin.getConfig();
+        SupportedMountType mountType = SupportedMountType.fromEntity(mount).orElse(null);
+        if (mountType == null || !mountType.isEnabled(config) || !isTrampleEnabled(config, mountType)) {
+            return;
+        }
+
+        double minimumSpeed = Math.max(
+                0.0,
+                config.getDouble("settings.horse-trample.minimum-speed", DEFAULT_MINIMUM_TRAMPLE_SPEED)
+        );
+        if (mount.getVelocity().clone().setY(0).lengthSquared() < minimumSpeed * minimumSpeed) {
+            return;
+        }
+
         long now = System.currentTimeMillis();
         long cooldownMillis = Math.max(0L, Math.round(
                 config.getDouble("settings.horse-trample.cooldown-seconds", DEFAULT_COOLDOWN_SECONDS) * 1000.0
         ));
-
-        for (org.bukkit.World world : Bukkit.getWorlds()) {
-            for (AbstractHorse mount : world.getEntitiesByClass(AbstractHorse.class)) {
-                SupportedMountType mountType = SupportedMountType.fromEntity(mount).orElse(null);
-                if (mountType == null || !mountType.isEnabled(config) || !isTrampleEnabled(config, mountType)) {
-                    continue;
-                }
-                trample(mount, config, now, cooldownMillis);
-            }
-        }
-
+        trample(mount, rider, config, now, cooldownMillis);
         cleanupCooldowns(now, cooldownMillis);
     }
 
@@ -69,24 +71,7 @@ public class HorseTrampleListener implements Listener {
         return config.getBoolean("settings.horse-trample.mount-types." + mountType.getConfigKey() + ".enabled", false);
     }
 
-    private void trample(AbstractHorse mount, FileConfiguration config, long now, long cooldownMillis) {
-        Vector velocity = mount.getVelocity();
-        Player rider = mount.getPassengers().stream()
-                .filter(Player.class::isInstance)
-                .map(Player.class::cast)
-                .findFirst()
-                .orElse(null);
-        if (rider == null) {
-            return;
-        }
-        double minimumSpeed = Math.max(
-                0.0,
-                config.getDouble("settings.horse-trample.minimum-speed", DEFAULT_MINIMUM_TRAMPLE_SPEED)
-        );
-        if (velocity.clone().setY(0).lengthSquared() < minimumSpeed * minimumSpeed) {
-            return;
-        }
-
+    private void trample(AbstractHorse mount, Player rider, FileConfiguration config, long now, long cooldownMillis) {
         double damage = Math.max(0.0, config.getDouble("settings.horse-trample.damage", DEFAULT_DAMAGE));
         if (damage <= 0.0) {
             return;
@@ -108,7 +93,7 @@ public class HorseTrampleListener implements Listener {
             if (!(nearby instanceof LivingEntity target) || target.equals(mount) || mount.getPassengers().contains(target)) {
                 continue;
             }
-            if (!isInTrampleHitbox(mount, target, horizontalRadius, verticalRadius, config)) {
+            if (!isInTrampleHitbox(mount, rider, target, horizontalRadius, verticalRadius, config)) {
                 continue;
             }
             if (isOnCooldown(mount.getUniqueId(), target.getUniqueId(), now, cooldownMillis)) {
@@ -128,6 +113,7 @@ public class HorseTrampleListener implements Listener {
 
     private boolean isInTrampleHitbox(
             AbstractHorse mount,
+            Player rider,
             LivingEntity target,
             double horizontalRadius,
             double verticalRadius,
@@ -145,15 +131,6 @@ public class HorseTrampleListener implements Listener {
         }
         if (toTarget.lengthSquared() == 0) {
             return true;
-        }
-
-        Player rider = mount.getPassengers().stream()
-                .filter(Player.class::isInstance)
-                .map(Player.class::cast)
-                .findFirst()
-                .orElse(null);
-        if (rider == null) {
-            return false;
         }
 
         Vector direction = rider.getLocation().getDirection().setY(0);


### PR DESCRIPTION
### Motivation
- Replace the scheduled world-scan trample loop with on-demand checks so trampling only runs when a player moves while mounted and uses the existing config settings for mount types and behavior.
- Ensure trampling uses the rider's look direction for hit detection and knockback, and keeps the existing damage event/cancel flow and per-target cooldowns.

### Description
- Replaced the repeating `tick` / scheduler approach with a `@EventHandler` for `PlayerMoveEvent` that returns early unless the moving player is riding a supported, trample-enabled mount and meets the configured `minimum-speed` threshold.
- Moved trample logic to `trample(AbstractHorse mount, Player rider, FileConfiguration config, long now, long cooldownMillis)` and updated `isInTrampleHitbox` to accept the `Player rider` so front-cone checks use the rider view direction.
- Removed the `BukkitTask` / `start()` lifecycle from `HorseTrampleListener` and simplified plugin registration in `BetterHorses` to register the listener without starting a task.
- Kept all config-backed settings intact: `settings.horse-trample.*` (damage, cooldown-seconds, minimum-speed, hitbox radii, front-dot-threshold, mount-types, knockback.enabled/strength) and preserved the damage event -> apply damage/knockback flow and per-mount per-target cooldown tracking.

### Testing
- Ran `git diff --check` to validate formatting and found no whitespace errors.
- Ran the build with `./gradlew build` (invoked with `JAVA_HOME=/root/.local/share/mise/installs/java/21.0.2`) and `compileJava` failed due to remote Maven repositories returning HTTP 403 when resolving compile-time dependencies, so a full successful build could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36e74129e4832ba427de8f9152ff03)