### PR TITLE
Use Kyori Adventure (BukkitAudiences) + MiniMessage for all language output

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
@@ -91,6 +91,10 @@ public class BetterHorses extends JavaPlugin {
         return languageManager;
     }
 
+    public BukkitAudiences getAudiences() {
+        return audiences;
+    }
+
     private void initializeConfigurationFiles() {
         saveDefaultConfig();
         reloadConfig();

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/CustomHorseCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/CustomHorseCommand.java
@@ -25,19 +25,19 @@ public class CustomHorseCommand implements CommandExecutor {
         plugin.debugLog("HORSE_CREATE", "RECEIVED", true, "Sender=" + sender.getName() + ", args=" + args.length + ".");
 
         if (!(sender instanceof Player player)) {
-            sender.sendMessage(lang.get("messages.only-players"));
+            lang.send(sender, "messages.only-players");
             plugin.debugLog("HORSE_CREATE", "PLAYER_REQUIRED", false, "Non-player sender attempted /horsecreate.");
             return true;
         }
 
         if (!player.hasPermission("betterhorses.create")) {
-            player.sendMessage(lang.getFormatted(player, "messages.insufficient-permission", "%command%", "/horsecreate"));
+            lang.sendFormatted(player, "messages.insufficient-permission", "%command%", "/horsecreate");
             plugin.debugLog("HORSE_CREATE", "PERMISSION", false, "Player " + player.getName() + " lacks betterhorses.create.");
             return true;
         }
 
         if (args.length < 3) {
-            player.sendMessage(lang.get(player, "messages.horsecreate-usage"));
+            lang.send(player, "messages.horsecreate-usage");
             plugin.debugLog("HORSE_CREATE", "USAGE", false, "Player " + player.getName() + " provided too few arguments.");
             return true;
         }
@@ -57,13 +57,13 @@ public class CustomHorseCommand implements CommandExecutor {
 
             SupportedMountType mountType = mountTypeArg == null ? SupportedMountType.HORSE : SupportedMountType.fromUserInput(mountTypeArg).orElse(null);
             if (mountType == null) {
-                player.sendMessage(lang.getFormatted(player, "messages.invalid-mount-type", "%types%", getEnabledMountTypes(config)));
+                lang.sendFormatted(player, "messages.invalid-mount-type", "%types%", getEnabledMountTypes(config));
                 plugin.debugLog("HORSE_CREATE", "MOUNT_TYPE", false, "Invalid mount type input: " + mountTypeArg);
                 return true;
             }
 
             if (!mountType.isEnabled(config)) {
-                player.sendMessage(lang.get(player, "messages.mount-type-disabled"));
+                lang.send(player, "messages.mount-type-disabled");
                 plugin.debugLog("HORSE_CREATE", "MOUNT_TYPE", false, "Disabled mount type requested: " + mountType.getEntityType());
                 return true;
             }
@@ -72,14 +72,14 @@ public class CustomHorseCommand implements CommandExecutor {
 
             if (trait != null && !trait.equalsIgnoreCase("none")) {
                 if (!config.getBoolean("traits.enabled", false)) {
-                    player.sendMessage(lang.get(player, "messages.traits-disabled"));
+                    lang.send(player, "messages.traits-disabled");
                     plugin.debugLog("HORSE_CREATE", "TRAIT", false, "Trait requested while traits are disabled.");
                     return true;
                 }
 
                 ConfigurationSection traitSection = config.getConfigurationSection("traits." + trait);
                 if (traitSection == null || !traitSection.getBoolean("enabled", false)) {
-                    player.sendMessage(lang.get(player, "messages.traits-error"));
+                    lang.send(player, "messages.traits-error");
                     plugin.debugLog("HORSE_CREATE", "TRAIT", false, "Invalid or disabled trait requested: " + trait);
                     return true;
                 }
@@ -93,7 +93,7 @@ public class CustomHorseCommand implements CommandExecutor {
             return true;
 
         } catch (NumberFormatException e) {
-            player.sendMessage(lang.get(player, "messages.invalid-number-format"));
+            lang.send(player, "messages.invalid-number-format");
             plugin.debugLog("HORSE_CREATE", "PARSE", false, "Invalid numeric argument from " + player.getName() + ": " + e.getMessage());
             return true;
         }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/DespawnCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/DespawnCommand.java
@@ -21,7 +21,7 @@ public class DespawnCommand {
         plugin.debugLog("HORSE_DESPAWN", "START", true, "Player " + player.getName() + " requested despawn.");
 
         if (!(player.getVehicle() instanceof AbstractHorse horse)) {
-            player.sendMessage(lang.get(player, "messages.invalid-vehicle"));
+            lang.send(player, "messages.invalid-vehicle");
             plugin.debugLog("HORSE_DESPAWN", "VALIDATION", false, "Player " + player.getName() + " is not riding a supported mount.");
             return true;
         }
@@ -31,7 +31,7 @@ public class DespawnCommand {
                 .orElse(null);
 
         if (mountType == null) {
-            player.sendMessage(lang.get(player, "messages.invalid-vehicle"));
+            lang.send(player, "messages.invalid-vehicle");
             plugin.debugLog("HORSE_DESPAWN", "MOUNT_TYPE", false, "Mount type disabled or unsupported for player " + player.getName() + ".");
             return true;
         }
@@ -49,14 +49,14 @@ public class DespawnCommand {
         }
 
         if (ownershipRequired && !isOwner) {
-            player.sendMessage(lang.getFormatted(player, "messages.not-horse-owner", "%mount%", mountName));
+            lang.sendFormatted(player, "messages.not-horse-owner", "%mount%", mountName);
             plugin.debugLog("HORSE_DESPAWN", "OWNERSHIP", false, "Player " + player.getName() + " is not owner of " + horse.getUniqueId() + ".");
             return true;
         }
 
         ItemStack item = BetterHorsesAPI.toItem(horse, player);
         if (item == null) {
-            player.sendMessage(lang.get(player, "messages.cant-despawn"));
+            lang.send(player, "messages.cant-despawn");
             plugin.debugLog("HORSE_DESPAWN", "ITEM", false, "Failed converting horse to item for " + horse.getUniqueId() + ".");
             return true;
         }
@@ -71,7 +71,7 @@ public class DespawnCommand {
         horse.remove();
 
         if (horse.isValid()) {
-            player.sendMessage(lang.get(player, "messages.cant-despawn"));
+            lang.send(player, "messages.cant-despawn");
             plugin.debugLog("HORSE_DESPAWN", "REMOVE", false, "Horse remained valid after remove call: " + horse.getUniqueId());
             return true;
         }
@@ -86,7 +86,7 @@ public class DespawnCommand {
             player.getInventory().addItem(item);
         }
 
-        player.sendMessage(lang.getFormatted(player, "messages.horse-despawned", "%mount%", mountName));
+        lang.sendFormatted(player, "messages.horse-despawned", "%mount%", mountName);
         plugin.debugLog("HORSE_DESPAWN", "COMPLETE", true, "Player " + player.getName() + " despawned " + mountName + ".");
         return true;
     }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseCommand.java
@@ -17,7 +17,7 @@ public class HorseCommand implements CommandExecutor {
         OfflinePlayer audience = sender instanceof Player senderPlayer ? senderPlayer : null;
 
         if (args.length == 0) {
-            sender.sendMessage(lang.get(audience, "messages.horse-usage"));
+            lang.send(sender, audience, "messages.horse-usage");
             return true;
         }
 
@@ -27,21 +27,21 @@ public class HorseCommand implements CommandExecutor {
 
         if (subcommand.equals("reload")) {
             if (!sender.hasPermission("betterhorses.reload")) {
-                sender.sendMessage(lang.getFormatted(audience, "messages.insufficient-permission", "%command%", "/horse reload"));
+                lang.sendFormatted(sender, audience, "messages.insufficient-permission", "%command%", "/horse reload");
                 plugin.debugLog("HORSE_COMMAND", "RELOAD_PERMISSION", false,
                         "Sender " + sender.getName() + " lacks betterhorses.reload");
                 return true;
             }
 
             plugin.reloadPluginConfiguration();
-            sender.sendMessage(lang.get(audience, "messages.config-reloaded"));
+            lang.send(sender, audience, "messages.config-reloaded");
             plugin.debugLog("HORSE_COMMAND", "RELOAD", true,
                     "Configuration reloaded by " + sender.getName());
             return true;
         }
 
         if (!(sender instanceof Player player)) {
-            sender.sendMessage(lang.get(audience, "messages.only-players"));
+            lang.send(sender, audience, "messages.only-players");
             plugin.debugLog("HORSE_COMMAND", "PLAYER_REQUIRED", false,
                     "Non-player sender tried subcommand " + subcommand);
             return true;
@@ -50,7 +50,7 @@ public class HorseCommand implements CommandExecutor {
         switch (subcommand) {
             case "spawn":
                 if (!player.hasPermission("betterhorses.base")) {
-                    player.sendMessage(lang.getFormatted(player, "messages.insufficient-permission", "%command%", "/horse spawn"));
+                    lang.sendFormatted(player, "messages.insufficient-permission", "%command%", "/horse spawn");
                     plugin.debugLog("HORSE_COMMAND", "SPAWN_PERMISSION", false,
                             "Player " + player.getName() + " lacks betterhorses.base");
                     return true;
@@ -59,7 +59,7 @@ public class HorseCommand implements CommandExecutor {
 
             case "despawn":
                 if (!player.hasPermission("betterhorses.base")) {
-                    player.sendMessage(lang.getFormatted(player, "messages.insufficient-permission", "%command%", "/horse despawn"));
+                    lang.sendFormatted(player, "messages.insufficient-permission", "%command%", "/horse despawn");
                     plugin.debugLog("HORSE_COMMAND", "DESPAWN_PERMISSION", false,
                             "Player " + player.getName() + " lacks betterhorses.base");
                     return true;
@@ -68,7 +68,7 @@ public class HorseCommand implements CommandExecutor {
 
             case "neuter":
                 if (!player.hasPermission("betterhorses.neuter")) {
-                    player.sendMessage(lang.getFormatted(player, "messages.insufficient-permission", "%command%", "/horse neuter"));
+                    lang.sendFormatted(player, "messages.insufficient-permission", "%command%", "/horse neuter");
                     plugin.debugLog("HORSE_COMMAND", "NEUTER_PERMISSION", false,
                             "Player " + player.getName() + " lacks betterhorses.neuter");
                     return true;
@@ -77,7 +77,7 @@ public class HorseCommand implements CommandExecutor {
 
             case "info":
                 if (!plugin.isDebugModeEnabled()) {
-                    player.sendMessage(lang.get(player, "messages.unknown-subcommand"));
+                    lang.send(player, "messages.unknown-subcommand");
                     plugin.debugLog("HORSE_COMMAND", "INFO_DEBUG_DISABLED", false,
                             "Player " + player.getName() + " used /horse info while debug mode is disabled.");
                     return true;
@@ -85,7 +85,7 @@ public class HorseCommand implements CommandExecutor {
                 return HorseInfoCommand.handle(player);
 
             default:
-                player.sendMessage(lang.get(player, "messages.unknown-subcommand"));
+                lang.send(player, "messages.unknown-subcommand");
                 plugin.debugLog("HORSE_COMMAND", "UNKNOWN_SUBCOMMAND", false,
                         "Player " + player.getName() + " used unknown subcommand: " + subcommand);
                 return true;

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseInfoCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseInfoCommand.java
@@ -189,9 +189,8 @@ public final class HorseInfoCommand {
             if (replaced.isEmpty()) {
                 continue;
             }
-            String parsed = plugin.getLang().parseToString(player, replaced);
-            for (String splitLine : parsed.split("\n", -1)) {
-                player.sendMessage(splitLine);
+            for (String splitLine : replaced.split("\n", -1)) {
+                plugin.getLang().sendRaw(player, splitLine);
             }
         }
     }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseNeuterCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseNeuterCommand.java
@@ -22,7 +22,7 @@ public class HorseNeuterCommand {
         LanguageManager lang = BetterHorses.getInstance().getLang();
 
         if (!player.hasPermission("betterhorses.neuter")) {
-            player.sendMessage(lang.getFormatted(player, "messages.insufficient-permission", "%command%", "/horse neuter"));
+            lang.sendFormatted(player, "messages.insufficient-permission", "%command%", "/horse neuter");
             BetterHorses.getInstance().debugLog("HORSE_NEUTER", "PERMISSION", false,
                     "Player " + player.getName() + " lacks betterhorses.neuter");
             return true;
@@ -33,7 +33,7 @@ public class HorseNeuterCommand {
         Material expected = Material.getMaterial(config.getString("settings.horse-item", "SADDLE").toUpperCase());
 
         if (expected == null || item == null || item.getType() != expected || !item.hasItemMeta()) {
-            player.sendMessage(lang.get(player, "messages.invalid-item"));
+            lang.send(player, "messages.invalid-item");
             BetterHorses.getInstance().debugLog("HORSE_NEUTER", "VALIDATION", false,
                     "Player " + player.getName() + " did not hold a valid horse item.");
             return true;
@@ -44,7 +44,7 @@ public class HorseNeuterCommand {
                 "Valid item detected for player " + player.getName());
 
         if (meta.getPersistentDataContainer().has(BetterHorseKeys.NEUTERED, PersistentDataType.BYTE)) {
-            player.sendMessage(lang.get(player, "messages.already-castrated"));
+            lang.send(player, "messages.already-castrated");
             BetterHorses.getInstance().debugLog("HORSE_NEUTER", "ALREADY_NEUTERED", false,
                     "Horse item is already neutered for player " + player.getName());
             return true;
@@ -69,7 +69,7 @@ public class HorseNeuterCommand {
 
         item.setItemMeta(meta);
         player.getInventory().setItemInMainHand(item);
-        player.sendMessage(lang.get(player, "messages.successfully-castrated"));
+        lang.send(player, "messages.successfully-castrated");
         BetterHorses.getInstance().debugLog("HORSE_NEUTER", "COMPLETE", true,
                 "Horse item neutered and written back to main hand for player " + player.getName());
         return true;

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/RespawnCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/RespawnCommand.java
@@ -26,7 +26,7 @@ public class RespawnCommand {
         if (expectedMaterial == null || !expectedMaterial.isItem()) expectedMaterial = Material.SADDLE;
 
         if (item == null || item.getType() != expectedMaterial || !item.hasItemMeta()) {
-            player.sendMessage(lang.get(player, "messages.invalid-item"));
+            lang.send(player, "messages.invalid-item");
             plugin.debugLog("HORSE_RESPAWN", "VALIDATION", false, "Invalid item used by " + player.getName() + ".");
             return true;
         }
@@ -40,21 +40,21 @@ public class RespawnCommand {
         String mountName = mountType.getDisplayName(lang, player);
 
         if (health == null || speed == null || jump == null || gender == null || !mountType.isEnabled(BetterHorses.getInstance().getConfig())) {
-            player.sendMessage(lang.getFormatted(player, "messages.invalid-horse-data", "%mount%", mountName));
+            lang.sendFormatted(player, "messages.invalid-horse-data", "%mount%", mountName);
             plugin.debugLog("HORSE_RESPAWN", "DATA", false, "Invalid horse data for " + player.getName() + ".");
             return true;
         }
 
         AbstractHorse horse = BetterHorsesAPI.toHorse(item, player);
         if (horse == null) {
-            player.sendMessage(lang.get(player, "messages.cant-spawn"));
+            lang.send(player, "messages.cant-spawn");
             plugin.debugLog("HORSE_RESPAWN", "SPAWN", false, "Mount spawn failed for " + player.getName() + ".");
             return true;
         }
 
         item.setAmount(item.getAmount() - 1);
         BetterHorsesAPI.callSpawnEvent(horse, item, BetterHorseSpawnEvent.SpawnCause.ITEM);
-        player.sendMessage(lang.getFormatted(player, "messages.horse-respawned", "%mount%", mountName));
+        lang.sendFormatted(player, "messages.horse-respawned", "%mount%", mountName);
         plugin.debugLog("HORSE_RESPAWN", "COMPLETE", true, "Player " + player.getName() + " spawned " + mountName + ".");
         return true;
     }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/language/LanguageManager.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/language/LanguageManager.java
@@ -8,9 +8,10 @@ import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.plugin.Plugin;
+import org.bukkit.entity.Player;
 
 import java.io.File;
 import java.util.Map;
@@ -117,6 +118,34 @@ public class LanguageManager {
 
     public Component getFormattedRawComponent(OfflinePlayer player, String key, Object... replacements) {
         return parse(player, replace(getRaw(key), replacements));
+    }
+
+    public void send(CommandSender sender, String key) {
+        send(sender, sender instanceof Player player ? player : null, key);
+    }
+
+    public void send(CommandSender sender, OfflinePlayer placeholderPlayer, String key) {
+        audiences.sender(sender).sendMessage(getComponent(placeholderPlayer, key));
+    }
+
+    public void send(Player player, String key) {
+        audiences.player(player).sendMessage(getComponent(player, key));
+    }
+
+    public void sendFormatted(CommandSender sender, String key, Object... replacements) {
+        sendFormatted(sender, sender instanceof Player player ? player : null, key, replacements);
+    }
+
+    public void sendFormatted(CommandSender sender, OfflinePlayer placeholderPlayer, String key, Object... replacements) {
+        audiences.sender(sender).sendMessage(getFormattedComponent(placeholderPlayer, key, replacements));
+    }
+
+    public void sendFormatted(Player player, String key, Object... replacements) {
+        audiences.player(player).sendMessage(getFormattedComponent(player, key, replacements));
+    }
+
+    public void sendRaw(Player player, String message) {
+        audiences.player(player).sendMessage(parse(player, message));
     }
 
     public Component parse(OfflinePlayer player, String message) {

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseMountListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseMountListener.java
@@ -36,10 +36,7 @@ public class HorseMountListener implements Listener {
 
         if (!player.getUniqueId().toString().equals(ownerUUID)) {
             event.setCancelled(true);
-            player.sendMessage(
-                    BetterHorses.getInstance().getLang()
-                            .getFormatted("messages.not-horse-owner")
-            );
+            BetterHorses.getInstance().getLang().sendFormatted(player, "messages.not-horse-owner");
         }
     }
 }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RightClickListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RightClickListener.java
@@ -58,13 +58,13 @@ public class RightClickListener implements Listener {
         String mountName = mountType.getDisplayName(lang, player);
 
         if (health == null || speed == null || jump == null || gender == null || !mountType.isEnabled(config)) {
-            player.sendMessage(lang.getFormatted(player, "messages.invalid-horse-data", "%mount%", mountName));
+            lang.sendFormatted(player, "messages.invalid-horse-data", "%mount%", mountName);
             return;
         }
 
         AbstractHorse horse = BetterHorsesAPI.toHorse(item, player);
         if (horse == null) {
-            player.sendMessage(lang.get(player, "messages.cant-spawn"));
+            lang.send(player, "messages.cant-spawn");
             return;
         }
 
@@ -72,6 +72,6 @@ public class RightClickListener implements Listener {
         TrainingManager.recalculateAndApplyBonuses(horse);
 
         item.setAmount(item.getAmount() - 1);
-        player.sendMessage(lang.getFormatted(player, "messages.horse-respawned", "%mount%", mountName));
+        lang.sendFormatted(player, "messages.horse-respawned", "%mount%", mountName);
     }
 }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/traits/TraitRegistry.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/traits/TraitRegistry.java
@@ -52,7 +52,7 @@ public class TraitRegistry {
 
         int duration = config.getInt("traits.hellmare.duration", 10);
         int radius = config.getInt("traits.hellmare.radius", 1);
-        player.sendMessage(lang.get(player, "traits.hellmare-message"));
+        lang.send(player, "traits.hellmare-message");
 
         PotionEffect fireResist = new PotionEffect(PotionEffectType.FIRE_RESISTANCE, duration * 20, 1, false, false, false);
         player.addPotionEffect(fireResist);
@@ -160,7 +160,7 @@ public class TraitRegistry {
         double boostedSpeed = originalSpeed * 1.5;
 
         speedAttr.setBaseValue(boostedSpeed);
-        player.sendMessage(lang.get(player, "traits.dashboost-message"));
+        lang.send(player, "traits.dashboost-message");
 
         setCooldown(horse, key, config.getInt("traits.dashboost.cooldown", 30));
 
@@ -209,7 +209,7 @@ public class TraitRegistry {
         }
 
         int duration = config.getInt("traits.ghosthorse.duration", 5);
-        player.sendMessage(lang.get(player, "traits.ghosthorse-message"));
+        lang.send(player, "traits.ghosthorse-message");
 
         horse.setInvisible(true);
         player.setInvisible(true);
@@ -279,7 +279,7 @@ public class TraitRegistry {
         }
 
         int duration = config.getInt("traits.revenantcurse.duration", 5);
-        player.sendMessage(lang.get(player, "traits.revenantcurse-message"));
+        lang.send(player, "traits.revenantcurse-message");
 
         horse.getPersistentDataContainer().set(
                 new NamespacedKey(BetterHorses.getInstance(), "revenantcurse_active"),
@@ -318,7 +318,7 @@ public class TraitRegistry {
             }
         }
 
-        player.sendMessage(lang.get(player, "traits.kickback-message"));
+        lang.send(player, "traits.kickback-message");
         setCooldown(horse, key, config.getInt("traits.kickback.cooldown", 10));
     }
 


### PR DESCRIPTION
### Motivation

- Migrate all chat output to Kyori Adventure so messages render via `MiniMessage` and work consistently on Paper and Spigot using `BukkitAudiences`.
- Centralize the audience-based send logic in `LanguageManager` while keeping the existing placeholder and language-file behavior intact.

### Description

- Added audience-backed helpers to `LanguageManager` (`send`, `sendFormatted`, `sendRaw`) that use the provided `BukkitAudiences` instance and `MiniMessage.miniMessage().deserialize(...)` for parsing.
- Kept existing placeholder parsing, legacy color-to-MiniMessage conversion, config loading, and message keys; the legacy-to-MiniMessage conversion still runs before MiniMessage parsing.
- Exposed the plugin audiences via `BetterHorses#getAudiences()` and pass the `BukkitAudiences` instance into `LanguageManager` on startup.
- Replaced direct `Player.sendMessage(...)` / `CommandSender.sendMessage(...)` usages across commands, listeners and traits with the new `LanguageManager` audience-based methods and updated multi-line template sending to use `sendRaw`.

### Testing

- Ran a repository-wide search for `sendMessage(` and for `lang.send`/`sendFormatted` usages to verify direct message calls were replaced, which succeeded with no remaining direct `sendMessage` usages in plugin source files.
- Ran `git diff --check` to ensure no whitespace/merge issues were introduced, which returned clean.
- Attempted to run `./gradlew build` inside the container, but the build was blocked by the environment Java/Gradle mismatch (`Unsupported class file major version 69`) so a full compile/test run could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ee464521c832ba81aa2a954f876cb)