### PR TITLE
Use reflective access for horse armor to fix Spigot NoClassDefFoundError

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/ArmorHider.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/ArmorHider.java
@@ -9,7 +9,6 @@ import me.luisgamedev.betterhorses.BetterHorses;
 import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.AbstractHorseInventory;
-import org.bukkit.inventory.ArmoredHorseInventory;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
@@ -75,7 +74,7 @@ public class ArmorHider {
             // show horse armor
             AbstractHorseInventory inv = horse.getInventory();
             List<Pair<ItemSlot, ItemStack>> visibleHorse = new ArrayList<>();
-            ItemStack armor = inv instanceof ArmoredHorseInventory armored ? armored.getArmor() : null;
+            ItemStack armor = HorseArmorUtils.getArmor(inv);
             visibleHorse.add(new Pair<>(ItemSlot.CHEST, armor));
 
             PacketContainer horsePacket = new PacketContainer(PacketType.Play.Server.ENTITY_EQUIPMENT);

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/HorseArmorUtils.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/HorseArmorUtils.java
@@ -2,7 +2,6 @@ package me.luisgamedev.betterhorses.utils;
 
 import org.bukkit.Material;
 import org.bukkit.inventory.AbstractHorseInventory;
-import org.bukkit.inventory.ArmoredHorseInventory;
 import org.bukkit.inventory.ItemStack;
 
 import java.lang.reflect.Method;
@@ -15,12 +14,7 @@ public final class HorseArmorUtils {
     public static ItemStack getArmor(AbstractHorseInventory inventory) {
         if (inventory == null) return null;
 
-        ItemStack armor = null;
-        if (inventory instanceof ArmoredHorseInventory armoredInventory) {
-            armor = armoredInventory.getArmor();
-        } else {
-            armor = invokeGetter(inventory);
-        }
+        ItemStack armor = invokeGetter(inventory);
 
         if (armor == null || armor.getType() == Material.AIR) return null;
         return armor;
@@ -28,11 +22,6 @@ public final class HorseArmorUtils {
 
     public static void setArmor(AbstractHorseInventory inventory, ItemStack armor) {
         if (inventory == null || armor == null || armor.getType() == Material.AIR) return;
-
-        if (inventory instanceof ArmoredHorseInventory armoredInventory) {
-            armoredInventory.setArmor(armor);
-            return;
-        }
 
         invokeSetter(inventory, armor);
     }


### PR DESCRIPTION
### Motivation
- Fix a `NoClassDefFoundError` on Spigot caused by direct references to `ArmoredHorseInventory` while preserving existing armor save/load behavior. 
- Make `HorseArmorUtils` cross-compatible across Paper/Spigot (and forks) for supported mounts without refactoring unrelated systems.

### Description
- Removed direct `org.bukkit.inventory.ArmoredHorseInventory` imports and `instanceof` checks and replaced runtime access with reflective `getArmor()` / `setArmor(ItemStack)` invocations inside `HorseArmorUtils` while keeping the public signatures unchanged.  
- Updated the `ArmorHider` callsite to use `HorseArmorUtils.getArmor(...)` instead of directly casting to `ArmoredHorseInventory`.  
- Preserved behavior: `getArmor(...)` returns `null` for missing/AIR armor and `setArmor(...)` is a no-op if given `null`/AIR or the inventory is incompatible.

### Testing
- Ran a codebase scan for direct references with `rg -n "ArmoredHorseInventory" -S .` and verified there are no remaining direct usages in the modified source files (success).  
- Ran `git diff --check` to ensure no trivial whitespace/problems were introduced (success).  
- Attempted a full build with `./gradlew build` under a compatible JDK, but the build could not complete in this environment due to repository access returning HTTP `403 Forbidden` for external Maven artifacts, so an end-to-end compile could not be validated here (failure due to environment, not code changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ee877eb94832bac7b50d3a7ed01e0)