### PR TITLE
Add configurable horse Trample feature

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
@@ -281,6 +281,11 @@ public class BetterHorses extends JavaPlugin {
             debugLog("LISTENER", "REGISTER", true, "Registered SandSlownessListener.");
         }
 
+        if (config.getBoolean("trample.enabled", true)) {
+            pluginManager.registerEvents(new TrampleListener(this), this);
+            debugLog("LISTENER", "REGISTER", true, "Registered TrampleListener.");
+        }
+
         if (!config.getBoolean("traits.enabled", true)) {
             debugLog("LISTENER", "REGISTER_TRAITS", false, "Trait listeners were skipped because traits are disabled.");
             return;

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/TrampleListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/TrampleListener.java
@@ -1,0 +1,190 @@
+package me.luisgamedev.betterhorses.listeners;
+
+import me.luisgamedev.betterhorses.BetterHorses;
+import me.luisgamedev.betterhorses.utils.SupportedMountType;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.AbstractHorse;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.ExperienceOrb;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.entity.Vehicle;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.Vector;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.UUID;
+
+public class TrampleListener implements Listener {
+
+    private final BetterHorses plugin;
+    private final Map<UUID, Location> previousHorseLocations = new HashMap<>();
+    private final Map<UUID, Long> targetCooldowns = new HashMap<>();
+    private long currentTick = 0L;
+
+    public TrampleListener(BetterHorses plugin) {
+        this.plugin = plugin;
+        startTrampleTask();
+    }
+
+    private void startTrampleTask() {
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                tickTrample();
+            }
+        }.runTaskTimer(plugin, 1L, 1L);
+    }
+
+    private void tickTrample() {
+        FileConfiguration config = plugin.getConfig();
+        if (!config.getBoolean("trample.enabled", true)) {
+            return;
+        }
+
+        currentTick++;
+        cleanupCooldowns(currentTick);
+
+        for (Player rider : Bukkit.getOnlinePlayers()) {
+            if (!(rider.getVehicle() instanceof AbstractHorse horse)) {
+                continue;
+            }
+            if (!SupportedMountType.isSupported(horse)) {
+                continue;
+            }
+
+            Location currentLocation = horse.getLocation();
+            Location previousLocation = previousHorseLocations.put(horse.getUniqueId(), currentLocation.clone());
+            if (previousLocation == null || previousLocation.getWorld() != currentLocation.getWorld()) {
+                continue;
+            }
+
+            double currentSpeed = currentLocation.distance(previousLocation);
+            if (currentSpeed <= 0.0) {
+                continue;
+            }
+
+            double minSpeed = config.getDouble("trample.min-speed", 0.15);
+            if (minSpeed > 0.0 && currentSpeed < minSpeed) {
+                continue;
+            }
+
+            trampleNearbyTargets(rider, horse, currentLocation, config, currentTick);
+        }
+    }
+
+    private void trampleNearbyTargets(Player rider, AbstractHorse horse, Location horseLocation, FileConfiguration config, long currentTick) {
+        double radius = Math.max(0.0, config.getDouble("trample.radius", 1.2));
+        if (radius <= 0.0) {
+            return;
+        }
+
+        double hitAngleDegrees = config.getDouble("trample.hit-angle-degrees", 90.0);
+        double minimumDot = Math.cos(Math.toRadians(Math.max(0.0, Math.min(360.0, hitAngleDegrees)) / 2.0));
+        Vector horseForward = horseLocation.getDirection();
+        if (horseForward.lengthSquared() == 0.0) {
+            return;
+        }
+        horseForward.normalize();
+
+        for (Entity entity : horse.getNearbyEntities(radius, radius, radius)) {
+            if (!isValidTarget(entity, rider, horse, config)) {
+                continue;
+            }
+            if (isOnCooldown(entity, currentTick)) {
+                continue;
+            }
+            if (!isInsideHitCone(horseLocation, horseForward, entity, hitAngleDegrees, minimumDot)) {
+                continue;
+            }
+
+            applyTrample(rider, horseLocation, (LivingEntity) entity, config, currentTick);
+        }
+    }
+
+    private boolean isValidTarget(Entity entity, Player rider, AbstractHorse horse, FileConfiguration config) {
+        if (entity == rider || entity == horse) return false;
+        if (!(entity instanceof LivingEntity livingEntity)) return false;
+        if (entity instanceof ArmorStand) return false;
+        if (entity instanceof Item) return false;
+        if (entity instanceof ExperienceOrb) return false;
+        if (entity instanceof Projectile) return false;
+        if (entity instanceof Vehicle) return false;
+        if (livingEntity.isDead() || !livingEntity.isValid() || livingEntity.isInvulnerable()) return false;
+
+        if (livingEntity instanceof Player) {
+            return config.getBoolean("trample.affect-players", false);
+        }
+        return config.getBoolean("trample.affect-mobs", true);
+    }
+
+    private boolean isOnCooldown(Entity entity, long currentTick) {
+        Long cooldownUntil = targetCooldowns.get(entity.getUniqueId());
+        return cooldownUntil != null && cooldownUntil > currentTick;
+    }
+
+    private boolean isInsideHitCone(Location horseLocation, Vector horseForward, Entity target, double hitAngleDegrees, double minimumDot) {
+        if (hitAngleDegrees >= 360.0) {
+            return true;
+        }
+
+        Vector toTarget = target.getLocation().toVector().subtract(horseLocation.toVector());
+        if (toTarget.lengthSquared() == 0.0) {
+            return true;
+        }
+
+        double dot = horseForward.dot(toTarget.normalize());
+        return dot >= minimumDot;
+    }
+
+    private void applyTrample(Player rider, Location horseLocation, LivingEntity target, FileConfiguration config, long currentTick) {
+        double damage = Math.max(0.0, config.getDouble("trample.damage", 4.0));
+        double knockbackStrength = Math.max(0.0, config.getDouble("trample.knockback", 1.2));
+
+        EntityDamageByEntityEvent damageEvent = new EntityDamageByEntityEvent(
+                rider,
+                target,
+                EntityDamageEvent.DamageCause.ENTITY_ATTACK,
+                damage
+        );
+        Bukkit.getPluginManager().callEvent(damageEvent);
+        if (damageEvent.isCancelled()) {
+            return;
+        }
+
+        int cooldownTicks = Math.max(0, config.getInt("trample.cooldown-ticks", 20));
+        targetCooldowns.put(target.getUniqueId(), currentTick + cooldownTicks);
+
+        if (damageEvent.getDamage() > 0.0) {
+            target.damage(damageEvent.getDamage(), rider);
+        }
+
+        if (knockbackStrength > 0.0) {
+            Vector knockback = target.getLocation().toVector().subtract(horseLocation.toVector());
+            if (knockback.lengthSquared() > 0.0) {
+                knockback.normalize().multiply(knockbackStrength);
+                knockback.setY(Math.max(0.2, knockback.getY() + 0.2));
+                target.setVelocity(knockback);
+            }
+        }
+    }
+
+    private void cleanupCooldowns(long currentTick) {
+        Iterator<Map.Entry<UUID, Long>> iterator = targetCooldowns.entrySet().iterator();
+        while (iterator.hasNext()) {
+            if (iterator.next().getValue() <= currentTick) {
+                iterator.remove();
+            }
+        }
+    }
+}

--- a/BetterHorses/src/main/resources/config.yml
+++ b/BetterHorses/src/main/resources/config.yml
@@ -152,6 +152,19 @@ settings:
     # If true, the trait cooldown is shown above the hotbar when using an ability that is currently on cooldown
     show-hotbar-indicator: true
 
+
+# Damages and knocks back nearby entities when a player rides a moving horse through them.
+trample:
+  enabled: true
+  damage: 4.0
+  knockback: 1.2
+  radius: 1.2
+  cooldown-ticks: 20
+  affect-players: false
+  affect-mobs: true
+  hit-angle-degrees: 90.0
+  min-speed: 0.15
+
 # Horse Abilities
 traits:
   # Set this to false to disable the whole trait feature


### PR DESCRIPTION
### Motivation
- Provide a new mount ability that lets a player-ridden horse damage and knock back nearby entities when the horse runs through them, with configurable tuning for damage, radius, knockback, cooldown and target filtering.
- Ensure the feature is lightweight, only scans nearby entities, respects target protections, and works on Spigot and Paper 1.20.4+ without changing unrelated systems.

### Description
- Added a new isolated listener `TrampleListener` that runs a 1-tick repeating task, tracks previous horse locations, computes real per-tick movement speed, and enforces `trample.min-speed` before processing hits.
- Scans only `horse.getNearbyEntities(radius, radius, radius)` and filters targets by type (ignores rider, ridden horse, armor stands, items, XP orbs, projectiles, vehicles, non-living, dead/invulnerable), and by `trample.affect-players` / `trample.affect-mobs` configuration.
- Uses horse forward direction and a dot-product cone check against `trample.hit-angle-degrees` to only hit entities in front of the horse, applies a per-target cooldown from `trample.cooldown-ticks`, and prevents hitting the same entity each tick.
- Fires a cancellable `EntityDamageByEntityEvent` with the player as the damager before applying damage, then applies damage via `target.damage(damage, rider)` and knockback via `target.setVelocity(...)` when the event is not cancelled.
- Registers `TrampleListener` from `BetterHorses` only when `trample.enabled` is true and adds a default `trample` block to `src/main/resources/config.yml` with the requested options (`enabled`, `damage`, `knockback`, `radius`, `cooldown-ticks`, `affect-players`, `affect-mobs`, `hit-angle-degrees`, `min-speed`).

### Testing
- Ran `git diff --check` which reported no whitespace errors and the patch was staged successfully. 
- Attempted `./gradlew build` on the environment Java 25 but the Gradle toolchain failed due to unsupported class file major version and the build did not run to completion. 
- Attempted the build again using a Java 21 toolchain via `JAVA_HOME=... ./gradlew build`, which invoked compilation but dependency resolution failed because remote Maven repositories returned HTTP 403, so a full compile/test could not be completed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fa6e70c5c832b9b92a011713da0dc)