### PR TITLE
Add per-item texture/model support for horse items (CustomModelData, item model, CIT, model string)

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorse.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorse.java
@@ -76,6 +76,33 @@ public final class BetterHorse {
         handle.getPersistentDataContainer().set(BetterHorseKeys.GROWTH_STAGE, PersistentDataType.INTEGER, stage);
     }
 
+    public HorseItemTextureData getTextureData() {
+        PersistentDataContainer data = handle.getPersistentDataContainer();
+        return new HorseItemTextureData(
+                data.get(BetterHorseKeys.TEXTURE_CUSTOM_MODEL_DATA, PersistentDataType.INTEGER),
+                data.get(BetterHorseKeys.TEXTURE_ITEM_MODEL, PersistentDataType.STRING),
+                data.get(BetterHorseKeys.TEXTURE_CIT_STRING, PersistentDataType.STRING),
+                data.get(BetterHorseKeys.TEXTURE_MODEL_STRING, PersistentDataType.STRING)
+        );
+    }
+
+    public void setTextureData(HorseItemTextureData textureData) {
+        PersistentDataContainer data = handle.getPersistentDataContainer();
+        HorseItemTextureData normalized = textureData == null ? HorseItemTextureData.empty() : textureData;
+        setOrRemove(data, BetterHorseKeys.TEXTURE_CUSTOM_MODEL_DATA, PersistentDataType.INTEGER, normalized.getCustomModelData());
+        setOrRemove(data, BetterHorseKeys.TEXTURE_ITEM_MODEL, PersistentDataType.STRING, normalized.getItemModel());
+        setOrRemove(data, BetterHorseKeys.TEXTURE_CIT_STRING, PersistentDataType.STRING, normalized.getCitString());
+        setOrRemove(data, BetterHorseKeys.TEXTURE_MODEL_STRING, PersistentDataType.STRING, normalized.getModelString());
+    }
+
+    private <T> void setOrRemove(PersistentDataContainer data, NamespacedKey key, PersistentDataType<?, T> type, T value) {
+        if (value == null) {
+            data.remove(key);
+        } else {
+            data.set(key, type, value);
+        }
+    }
+
     private void setAttribute(Attribute attribute, NamespacedKey key, double value) {
         AttributeInstance attr = handle.getAttribute(attribute);
         if (attr != null) {

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorseItem.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorseItem.java
@@ -40,6 +40,14 @@ public final class BetterHorseItem {
         return Optional.ofNullable(data.get(BetterHorseKeys.MOUNT_TYPE, PersistentDataType.STRING));
     }
 
+    public HorseItemTextureData getTextureData() {
+        return BetterHorsesAPI.getTextureData(itemStack);
+    }
+
+    public void setTextureData(HorseItemTextureData textureData) {
+        BetterHorsesAPI.applyTextureData(itemStack, textureData);
+    }
+
     private Optional<Double> getDouble(org.bukkit.NamespacedKey key) {
         ItemMeta meta = itemStack.getItemMeta();
         PersistentDataContainer data = meta.getPersistentDataContainer();

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorseKeys.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorseKeys.java
@@ -35,6 +35,10 @@ public final class BetterHorseKeys {
     public static final NamespacedKey TRAINING_FEEDING_UNITS = key("training_feeding_units");
     public static final NamespacedKey TRAINING_BRUSH_COOLDOWN = key("training_brush_cooldown");
     public static final NamespacedKey TRAINING_FEED_COOLDOWN = key("training_feed_cooldown");
+    public static final NamespacedKey TEXTURE_CUSTOM_MODEL_DATA = key("texture_custom_model_data");
+    public static final NamespacedKey TEXTURE_ITEM_MODEL = key("texture_item_model");
+    public static final NamespacedKey TEXTURE_CIT_STRING = key("texture_cit_string");
+    public static final NamespacedKey TEXTURE_MODEL_STRING = key("texture_model_string");
 
     private static NamespacedKey key(String key) {
         return new NamespacedKey(BetterHorses.getInstance(), key);

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
@@ -33,6 +33,7 @@ import org.bukkit.persistence.PersistentDataType;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -45,6 +46,11 @@ public class BetterHorsesAPI {
 
     @Description("Creates a horseitem and either returns the ItemStack or directly puts it into the provided Inventory")
     public static ItemStack createHorseItem(@Nonnull double health, @Nonnull double speed, @Nonnull double jump, @Nonnull String gender, @Nullable String name, @Nullable Player owner, @Nullable Inventory targetInventory, @Nullable boolean dropIfFull, @Nullable String traitOverride, @Nonnull boolean isNeutered, @Nonnull Integer growthStage, @Nullable SupportedMountType mountType) {
+        return createHorseItem(health, speed, jump, gender, name, owner, targetInventory, dropIfFull, traitOverride, isNeutered, growthStage, mountType, getConfiguredTextureData());
+    }
+
+    @Description("Creates a horseitem with explicit texture/model references and either returns the ItemStack or directly puts it into the provided Inventory")
+    public static ItemStack createHorseItem(@Nonnull double health, @Nonnull double speed, @Nonnull double jump, @Nonnull String gender, @Nullable String name, @Nullable Player owner, @Nullable Inventory targetInventory, @Nullable boolean dropIfFull, @Nullable String traitOverride, @Nonnull boolean isNeutered, @Nonnull Integer growthStage, @Nullable SupportedMountType mountType, @Nullable HorseItemTextureData textureData) {
 
         BetterHorses plugin = BetterHorses.getInstance();
         LanguageManager lang = plugin.getLang();
@@ -71,7 +77,7 @@ public class BetterHorsesAPI {
         if(owner != null) {
             data.set(BetterHorseKeys.OWNER, PersistentDataType.STRING, owner.getUniqueId().toString());
         }
-        data.set(BetterHorseKeys.NAME, PersistentDataType.STRING, name.replace(ChatColor.GOLD.toString(), ""));
+        data.set(BetterHorseKeys.NAME, PersistentDataType.STRING, (name == null ? "" : name).replace(ChatColor.GOLD.toString(), ""));
         data.set(BetterHorseKeys.STYLE, PersistentDataType.STRING, Horse.Style.WHITE.name());
         data.set(BetterHorseKeys.COLOR, PersistentDataType.STRING, Horse.Color.CREAMY.name());
         data.set(BetterHorseKeys.GROWTH_STAGE, PersistentDataType.INTEGER, growth);
@@ -80,6 +86,7 @@ public class BetterHorsesAPI {
             data.set(BetterHorseKeys.NEUTERED, PersistentDataType.BYTE, (byte) 1);
         }
         TrainingManager.ensureTrainingData(data);
+        applyTextureData(meta, textureData);
 
         FileConfiguration config = plugin.getConfig();
         String traitForLore = null;
@@ -245,6 +252,7 @@ public class BetterHorsesAPI {
         horseData.set(BetterHorseKeys.OWNER, PersistentDataType.STRING, ownerUUID);
         horseData.set(BetterHorseKeys.GENDER, PersistentDataType.STRING, gender);
         horseData.set(BetterHorseKeys.MOUNT_TYPE, PersistentDataType.STRING, mountType.getEntityType().name());
+        copyTextureData(data, horseData);
 
         if (trait != null && !trait.isBlank()) {
             horseData.set(BetterHorseKeys.TRAIT, PersistentDataType.STRING, trait);
@@ -393,9 +401,91 @@ public class BetterHorsesAPI {
             itemData.set(BetterHorseKeys.ARMOR, PersistentDataType.STRING, armor.getType().name());
             itemData.set(BetterHorseKeys.ARMOR_DATA, PersistentDataType.STRING, Base64.getEncoder().encodeToString(armor.serializeAsBytes()));
         }
+        HorseItemTextureData textureData = readTextureData(data);
+        if (textureData.isEmpty()) {
+            textureData = getConfiguredTextureData();
+        }
+        applyTextureData(meta, textureData);
 
         item.setItemMeta(meta);
         return item;
+    }
+
+
+    public static HorseItemTextureData getConfiguredTextureData() {
+        FileConfiguration config = BetterHorses.getInstance().getConfig();
+        return new HorseItemTextureData(
+                config.getInt("settings.texture.custom-model-data", 0),
+                config.getString("settings.texture.item-model", ""),
+                config.getString("settings.texture.cit-string", ""),
+                config.getString("settings.texture.model-string", "")
+        );
+    }
+
+    public static HorseItemTextureData getTextureData(@Nonnull ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return HorseItemTextureData.empty();
+        HorseItemTextureData pdcData = readTextureData(meta.getPersistentDataContainer());
+        Integer cmd = meta.hasCustomModelData() ? meta.getCustomModelData() : pdcData.getCustomModelData();
+        return new HorseItemTextureData(cmd, pdcData.getItemModel(), pdcData.getCitString(), pdcData.getModelString());
+    }
+
+    public static void applyTextureData(@Nonnull ItemStack item, @Nullable HorseItemTextureData textureData) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        applyTextureData(meta, textureData);
+        item.setItemMeta(meta);
+    }
+
+    private static HorseItemTextureData readTextureData(PersistentDataContainer data) {
+        return new HorseItemTextureData(
+                data.get(BetterHorseKeys.TEXTURE_CUSTOM_MODEL_DATA, PersistentDataType.INTEGER),
+                data.get(BetterHorseKeys.TEXTURE_ITEM_MODEL, PersistentDataType.STRING),
+                data.get(BetterHorseKeys.TEXTURE_CIT_STRING, PersistentDataType.STRING),
+                data.get(BetterHorseKeys.TEXTURE_MODEL_STRING, PersistentDataType.STRING)
+        );
+    }
+
+    private static void copyTextureData(PersistentDataContainer source, PersistentDataContainer target) {
+        applyTextureData(target, readTextureData(source));
+    }
+
+    private static void applyTextureData(ItemMeta meta, @Nullable HorseItemTextureData textureData) {
+        PersistentDataContainer data = meta.getPersistentDataContainer();
+        applyTextureData(data, textureData);
+        HorseItemTextureData normalized = textureData == null ? HorseItemTextureData.empty() : textureData;
+        if (normalized.getCustomModelData() != null) {
+            meta.setCustomModelData(normalized.getCustomModelData());
+        }
+        applyItemModel(meta, normalized.getItemModel());
+    }
+
+    private static void applyTextureData(PersistentDataContainer data, @Nullable HorseItemTextureData textureData) {
+        HorseItemTextureData normalized = textureData == null ? HorseItemTextureData.empty() : textureData;
+        setOrRemove(data, BetterHorseKeys.TEXTURE_CUSTOM_MODEL_DATA, PersistentDataType.INTEGER, normalized.getCustomModelData());
+        setOrRemove(data, BetterHorseKeys.TEXTURE_ITEM_MODEL, PersistentDataType.STRING, normalized.getItemModel());
+        setOrRemove(data, BetterHorseKeys.TEXTURE_CIT_STRING, PersistentDataType.STRING, normalized.getCitString());
+        setOrRemove(data, BetterHorseKeys.TEXTURE_MODEL_STRING, PersistentDataType.STRING, normalized.getModelString());
+    }
+
+    private static <T> void setOrRemove(PersistentDataContainer data, NamespacedKey key, PersistentDataType<?, T> type, @Nullable T value) {
+        if (value == null) {
+            data.remove(key);
+        } else {
+            data.set(key, type, value);
+        }
+    }
+
+    private static void applyItemModel(ItemMeta meta, @Nullable String itemModel) {
+        if (itemModel == null) return;
+        try {
+            Method method = meta.getClass().getMethod("setItemModel", NamespacedKey.class);
+            NamespacedKey key = NamespacedKey.fromString(itemModel);
+            if (key != null) {
+                method.invoke(meta, key);
+            }
+        } catch (ReflectiveOperationException | LinkageError ignored) {
+        }
     }
 
     private static String formatHorseItemName(LanguageManager lang, @Nullable Player player, @Nullable String name, String genderSymbol) {

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/HorseItemTextureData.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/HorseItemTextureData.java
@@ -1,0 +1,57 @@
+package me.luisgamedev.betterhorses.api;
+
+import javax.annotation.Nullable;
+
+/**
+ * Texture/model references that can be applied to BetterHorses horse items.
+ * Empty strings, null values, and non-positive custom model data values are
+ * treated as not configured.
+ */
+public final class HorseItemTextureData {
+
+    private final @Nullable Integer customModelData;
+    private final @Nullable String itemModel;
+    private final @Nullable String citString;
+    private final @Nullable String modelString;
+
+    public HorseItemTextureData(@Nullable Integer customModelData, @Nullable String itemModel, @Nullable String citString, @Nullable String modelString) {
+        this.customModelData = normalizeCustomModelData(customModelData);
+        this.itemModel = normalizeString(itemModel);
+        this.citString = normalizeString(citString);
+        this.modelString = normalizeString(modelString);
+    }
+
+    public static HorseItemTextureData empty() {
+        return new HorseItemTextureData(null, null, null, null);
+    }
+
+    public @Nullable Integer getCustomModelData() {
+        return customModelData;
+    }
+
+    public @Nullable String getItemModel() {
+        return itemModel;
+    }
+
+    public @Nullable String getCitString() {
+        return citString;
+    }
+
+    public @Nullable String getModelString() {
+        return modelString;
+    }
+
+    public boolean isEmpty() {
+        return customModelData == null && itemModel == null && citString == null && modelString == null;
+    }
+
+    private static @Nullable Integer normalizeCustomModelData(@Nullable Integer value) {
+        return value != null && value > 0 ? value : null;
+    }
+
+    private static @Nullable String normalizeString(@Nullable String value) {
+        if (value == null) return null;
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/BetterHorses/src/main/resources/config.yml
+++ b/BetterHorses/src/main/resources/config.yml
@@ -78,6 +78,14 @@ settings:
   # Customizes the original item a horse item is
   horse-item: SADDLE
 
+  # Optional texture/model references applied to all created horse items.
+  # Leave values empty or 0 to keep the default item appearance.
+  texture:
+    custom-model-data: 0
+    item-model: ""
+    cit-string: ""
+    model-string: ""
+
   # Controls which lore parts are shown for horse items and in what order.
   # Use nested sections to ensure child lines are only loaded when the parent section resolves to a visible line.
   # Available values: gender, health, speed, jump, growth, training, riding, brushing, feeding, trait, neutered, blank


### PR DESCRIPTION
### Motivation
- Allow horse items to reference custom resource-pack/model textures using all common methods (CustomModelData, item model NamespacedKey, CIT string, and model string) and make that data part of the BetterHorses API.
- Ensure texture/model references are preserved across horse -> item, item -> horse, despawn/respawn and are usable by external resource-pack/CIT systems via PDC.
- Keep the change minimal and backward-compatible so existing configs and plugins continue to work when the new config section is missing or values are empty.

### Description
- Added new API holder `HorseItemTextureData` with normalized fields `customModelData`, `itemModel`, `citString`, and `modelString`, treating blanks/null/<=0 as unset.
- Persisted new namespaced PDC keys in `BetterHorseKeys` and added helpers in `BetterHorsesAPI` to `read`, `apply`, `copy`, and `getConfiguredTextureData()` from `settings.texture`.
- Extended `BetterHorsesAPI#createHorseItem(...)` with a backward-compatible overload that accepts `HorseItemTextureData`, applied `CustomModelData` to `ItemMeta` and used reflection to call the modern `ItemMeta#setItemModel(NamespacedKey)` safely on supported platforms.
- Exposed `getTextureData()` / `setTextureData(...)` on `BetterHorseItem` and `BetterHorse` to let API consumers read and modify per-item or in-world horse texture references, and added config defaults under `settings.texture` to permit a single server-wide texture.

### Testing
- Ran `git diff --check` to validate whitespace and obvious diff issues and it reported no problems.
- Attempted to compile with `./gradlew compileJava` but the build was blocked in this environment due to local Java/Gradle JVM mismatch and a subsequent dependency resolution failure (remote repositories returned HTTP 403), so a full compile could not be completed here.
- No unit tests were added; runtime verification should be done on a Paper/Spigot server (recommended Java 17+/21 depending on server) to confirm `CustomModelData`, model key, and CIT persistence and reflection-path behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3faf380cd0832bb476e8045827be36)