### PR TITLE
Add configurable horse item texture override

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
@@ -86,7 +86,7 @@ public class BetterHorsesAPI {
             data.set(BetterHorseKeys.NEUTERED, PersistentDataType.BYTE, (byte) 1);
         }
         TrainingManager.ensureTrainingData(data);
-        applyTextureData(meta, textureData);
+        applyResolvedTextureData(meta, textureData);
 
         FileConfiguration config = plugin.getConfig();
         String traitForLore = null;
@@ -401,11 +401,7 @@ public class BetterHorsesAPI {
             itemData.set(BetterHorseKeys.ARMOR, PersistentDataType.STRING, armor.getType().name());
             itemData.set(BetterHorseKeys.ARMOR_DATA, PersistentDataType.STRING, Base64.getEncoder().encodeToString(armor.serializeAsBytes()));
         }
-        HorseItemTextureData textureData = readTextureData(data);
-        if (textureData.isEmpty()) {
-            textureData = getConfiguredTextureData();
-        }
-        applyTextureData(meta, textureData);
+        applyResolvedTextureData(meta, readTextureData(data));
 
         item.setItemMeta(meta);
         return item;
@@ -420,6 +416,28 @@ public class BetterHorsesAPI {
                 config.getString("settings.texture.cit-string", ""),
                 config.getString("settings.texture.model-string", "")
         );
+    }
+
+    private static boolean shouldOverrideTextureData() {
+        return BetterHorses.getInstance().getConfig().getBoolean("settings.texture.override-texture-data", false);
+    }
+
+    private static HorseItemTextureData resolveTextureData(@Nullable HorseItemTextureData textureData) {
+        HorseItemTextureData configured = getConfiguredTextureData();
+        HorseItemTextureData stored = textureData == null ? HorseItemTextureData.empty() : textureData;
+        if (shouldOverrideTextureData()) {
+            return configured;
+        }
+        return new HorseItemTextureData(
+                stored.getCustomModelData() != null ? stored.getCustomModelData() : configured.getCustomModelData(),
+                stored.getItemModel() != null ? stored.getItemModel() : configured.getItemModel(),
+                stored.getCitString() != null ? stored.getCitString() : configured.getCitString(),
+                stored.getModelString() != null ? stored.getModelString() : configured.getModelString()
+        );
+    }
+
+    private static void applyResolvedTextureData(ItemMeta meta, @Nullable HorseItemTextureData textureData) {
+        applyTextureData(meta, resolveTextureData(textureData));
     }
 
     public static HorseItemTextureData getTextureData(@Nonnull ItemStack item) {
@@ -454,9 +472,7 @@ public class BetterHorsesAPI {
         PersistentDataContainer data = meta.getPersistentDataContainer();
         applyTextureData(data, textureData);
         HorseItemTextureData normalized = textureData == null ? HorseItemTextureData.empty() : textureData;
-        if (normalized.getCustomModelData() != null) {
-            meta.setCustomModelData(normalized.getCustomModelData());
-        }
+        meta.setCustomModelData(normalized.getCustomModelData());
         applyItemModel(meta, normalized.getItemModel());
     }
 
@@ -477,11 +493,10 @@ public class BetterHorsesAPI {
     }
 
     private static void applyItemModel(ItemMeta meta, @Nullable String itemModel) {
-        if (itemModel == null) return;
         try {
             Method method = meta.getClass().getMethod("setItemModel", NamespacedKey.class);
-            NamespacedKey key = NamespacedKey.fromString(itemModel);
-            if (key != null) {
+            NamespacedKey key = itemModel == null ? null : NamespacedKey.fromString(itemModel);
+            if (itemModel == null || key != null) {
                 method.invoke(meta, key);
             }
         } catch (ReflectiveOperationException | LinkageError ignored) {

--- a/BetterHorses/src/main/resources/config.yml
+++ b/BetterHorses/src/main/resources/config.yml
@@ -81,6 +81,8 @@ settings:
   # Optional texture/model references applied to all created horse items.
   # Leave values empty or 0 to keep the default item appearance.
   texture:
+    # When enabled, the configured values below always override texture data stored on horse items or supplied through the API.
+    override-texture-data: false
     custom-model-data: 0
     item-model: ""
     cit-string: ""


### PR DESCRIPTION
### Motivation
- Allow server owners to force-configure horse item textures so config values can override any texture data stored on items or supplied via the API while preserving existing storage and API behavior.
- Provide per-field fallback behavior so config only supplies defaults for missing stored/API fields when override mode is disabled.

### Description
- Added `settings.texture.override-texture-data` (default `false`) to `config.yml` to toggle config-first texture resolution.
- Introduced `shouldOverrideTextureData()`, `resolveTextureData(...)`, and `applyResolvedTextureData(...)` in `BetterHorsesAPI` and routed horse->item and API-created item texture application through `applyResolvedTextureData(...)` so the new resolution order is used only when creating/applying textures.
- Implemented per-field resolution: when override is enabled the configured `HorseItemTextureData` is returned, otherwise stored/API values are used per-field and fall back to config values for missing fields.
- Adjusted texture application so `customModelData` and `itemModel` can be cleared by resolved empty/zero values while leaving PDC storage APIs and ability to set/read texture data intact.

### Testing
- Committed changes and verified diffs that replace direct `applyTextureData(...)` calls with `applyResolvedTextureData(...)` and the new config entry via `git` operations that completed successfully.
- Executed `./gradlew build` in the environment, which failed due to the local build environment using Java 25 and a Gradle/Groovy incompatibility (`Unsupported class file major version 69`), so no project build artifacts were produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fb6fad39c832b9ee41e944a27948e)