### PR TITLE
Add per-mount trample toggles

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/TrampleListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/TrampleListener.java
@@ -59,7 +59,8 @@ public class TrampleListener implements Listener {
             if (!(rider.getVehicle() instanceof AbstractHorse horse)) {
                 continue;
             }
-            if (!SupportedMountType.isSupported(horse)) {
+            SupportedMountType mountType = SupportedMountType.fromEntity(horse).orElse(null);
+            if (mountType == null || !mountType.isEnabled(config) || !isTrampleEnabled(config, mountType)) {
                 continue;
             }
 
@@ -81,6 +82,10 @@ public class TrampleListener implements Listener {
 
             trampleNearbyTargets(rider, horse, currentLocation, config, currentTick);
         }
+    }
+
+    private boolean isTrampleEnabled(FileConfiguration config, SupportedMountType mountType) {
+        return config.getBoolean("trample.mount-types." + mountType.getConfigKey(), true);
     }
 
     private void trampleNearbyTargets(Player rider, AbstractHorse horse, Location horseLocation, FileConfiguration config, long currentTick) {

--- a/BetterHorses/src/main/resources/config.yml
+++ b/BetterHorses/src/main/resources/config.yml
@@ -191,6 +191,15 @@ settings:
 # Damages and knocks back nearby entities when a player rides a horse through them.
 trample:
   enabled: false
+  # Toggle trample separately for each supported mount type.
+  # Horses remain available here even though they are always an enabled mount type.
+  mount-types:
+    horse: true
+    skeleton-horses: true
+    zombie-horses: true
+    camels: true
+    mules: true
+    donkeys: true
   damage: 4.0
   knockback: 1.5
   radius: 1.2

--- a/README.md
+++ b/README.md
@@ -149,6 +149,26 @@ settings:
     # If true, the trait cooldown is shown above the hotbar when using an ability that is currently on cooldown
     show-hotbar-indicator: true
 
+# Damages and knocks back nearby entities when a player rides a horse through them.
+trample:
+  enabled: false
+  # Toggle trample separately for each supported mount type.
+  mount-types:
+    horse: true
+    skeleton-horses: true
+    zombie-horses: true
+    camels: true
+    mules: true
+    donkeys: true
+  damage: 4.0
+  knockback: 1.5
+  radius: 1.2
+  cooldown-ticks: 20
+  affect-players: true
+  affect-mobs: true
+  hit-angle-degrees: 90.0
+  min-speed: 0.15
+
 # Horse Abilities
 traits:
   # Set this to false to disable the whole trait feature


### PR DESCRIPTION
### Motivation
- Allow server operators to enable or disable the trample feature independently for each supported mount type rather than only a global `trample.enabled` toggle.

### Description
- Add `trample.mount-types` entries to `BetterHorses/src/main/resources/config.yml` (keys: `horse`, `skeleton-horses`, `zombie-horses`, `camels`, `mules`, `donkeys`) and document them in `README.md`.
- Update `TrampleListener` to resolve the mount type via `SupportedMountType.fromEntity(...)`, require the mount type to be enabled via `mountType.isEnabled(config)`, and add `isTrampleEnabled(FileConfiguration, SupportedMountType)` to check the per-mount trample toggle before running trample logic.
- Preserve the existing global `trample.enabled` master switch and existing trample configuration options (`damage`, `radius`, `cooldown-ticks`, etc.).
- Modified files: `BetterHorses/src/main/resources/config.yml`, `BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/TrampleListener.java`, and `README.md`.

### Testing
- Parsed the modified YAML with `ruby -e "require 'yaml'; YAML.load_file('BetterHorses/src/main/resources/config.yml')"` which succeeded.
- Ran `git diff --check` which succeeded with no whitespace errors.
- Attempted to build with `./gradlew build` and it failed due to the environment Java/Groovy mismatch (`Unsupported class file major version 69`).
- Attempted build again with `JAVA_HOME=/root/.local/share/mise/installs/java/21.0.2 ./gradlew build`, which reached dependency resolution but failed because configured Maven repositories returned HTTP 403 for compile-only dependencies (dependency resolution failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fc6f24704832ba9f63bd76c4a6c30)