### PR TITLE
Add 'Undead' passive trait (skeleton transformation and restore)

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
@@ -301,6 +301,11 @@ public class BetterHorses extends JavaPlugin {
             debugLog("LISTENER", "REGISTER", true, "Registered TraitCleanupListener.");
         }
 
+        if (isAnyTraitEnabled("undead")) {
+            pluginManager.registerEvents(new UndeadTraitListener(), this);
+            debugLog("LISTENER", "REGISTER", true, "Registered UndeadTraitListener.");
+        }
+
         if (isAnyTraitEnabled("frosthooves", "featherhooves", "fireheart")) {
             pluginManager.registerEvents(new PassiveTraitListener(), this);
             debugLog("LISTENER", "REGISTER", true, "Registered PassiveTraitListener.");

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorseKeys.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorseKeys.java
@@ -41,6 +41,14 @@ public final class BetterHorseKeys {
     public static final NamespacedKey TEXTURE_ITEM_MODEL = key("texture_item_model");
     public static final NamespacedKey TEXTURE_CIT_STRING = key("texture_cit_string");
     public static final NamespacedKey TEXTURE_MODEL_STRING = key("texture_model_string");
+    public static final NamespacedKey UNDEAD_SKELETON = key("undead_skeleton");
+    public static final NamespacedKey UNDEAD_ORIGINAL_TYPE = key("undead_original_type");
+    public static final NamespacedKey UNDEAD_ORIGINAL_HEALTH = key("undead_original_health");
+    public static final NamespacedKey UNDEAD_ORIGINAL_SPEED = key("undead_original_speed");
+    public static final NamespacedKey UNDEAD_ORIGINAL_JUMP = key("undead_original_jump");
+    public static final NamespacedKey UNDEAD_ORIGINAL_COLOR = key("undead_original_color");
+    public static final NamespacedKey UNDEAD_ORIGINAL_STYLE = key("undead_original_style");
+    public static final NamespacedKey UNDEAD_ARMOR_DATA = key("undead_armor_data");
 
     private static NamespacedKey key(String key) {
         return new NamespacedKey(BetterHorses.getInstance(), key);

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/UndeadTraitListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/UndeadTraitListener.java
@@ -1,0 +1,168 @@
+package me.luisgamedev.betterhorses.listeners;
+
+import me.luisgamedev.betterhorses.BetterHorses;
+import me.luisgamedev.betterhorses.api.BetterHorseKeys;
+import me.luisgamedev.betterhorses.traits.TraitParticleResolver;
+import me.luisgamedev.betterhorses.utils.AttributeResolver;
+import me.luisgamedev.betterhorses.utils.HorseArmorUtils;
+import me.luisgamedev.betterhorses.utils.SupportedMountType;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.entity.AbstractHorse;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Horse;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.SkeletonHorse;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.util.List;
+import java.util.Locale;
+
+public class UndeadTraitListener implements Listener {
+    private static final String TRAIT = "undead";
+    private final BetterHorses plugin = BetterHorses.getInstance();
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onFatalDamage(EntityDamageEvent event) {
+        if (!(event.getEntity() instanceof AbstractHorse horse)) return;
+        if (horse instanceof SkeletonHorse && isUndeadSkeleton(horse)) return;
+        if (!SupportedMountType.isSupported(horse)) return;
+        if (!TRAIT.equalsIgnoreCase(horse.getPersistentDataContainer().get(BetterHorseKeys.TRAIT, PersistentDataType.STRING))) return;
+        if (event.getFinalDamage() < horse.getHealth()) return;
+        event.setCancelled(true);
+        transformToSkeleton(horse);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onFeed(PlayerInteractEntityEvent event) {
+        if (event.getHand() == EquipmentSlot.OFF_HAND) return;
+        if (!(event.getRightClicked() instanceof SkeletonHorse skeleton)) return;
+        if (!isUndeadSkeleton(skeleton)) return;
+        ItemStack item = event.getPlayer().getInventory().getItem(event.getHand());
+        if (item == null || item.getType() != getTransformBackItem()) return;
+        event.setCancelled(true);
+        if (item.getAmount() > 1) item.setAmount(item.getAmount() - 1); else event.getPlayer().getInventory().setItem(event.getHand(), null);
+        transformBack(skeleton);
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void onUndeadSkeletonDeath(EntityDeathEvent event) {
+        if (!(event.getEntity() instanceof SkeletonHorse skeleton)) return;
+        if (!isUndeadSkeleton(skeleton)) return;
+        ItemStack armor = readStoredArmor(skeleton.getPersistentDataContainer());
+        if (armor != null) event.getDrops().add(armor);
+    }
+
+    private void transformToSkeleton(AbstractHorse original) {
+        Location location = original.getLocation();
+        List<Entity> passengers = List.copyOf(original.getPassengers());
+        PersistentDataContainer oldData = original.getPersistentDataContainer();
+        double maxHealth = getAttribute(original, AttributeResolver.generic("MAX_HEALTH"), 20.0);
+        double speed = getAttribute(original, AttributeResolver.generic("MOVEMENT_SPEED"), 0.2);
+        double jump = getAttribute(original, AttributeResolver.horseJumpStrength(), 0.7);
+        ItemStack armor = HorseArmorUtils.getArmor(original.getInventory());
+        ItemStack saddle = original.getInventory().getSaddle();
+
+        SkeletonHorse skeleton = location.getWorld().spawn(location, SkeletonHorse.class);
+        copyBetterHorsesData(oldData, skeleton.getPersistentDataContainer());
+        PersistentDataContainer data = skeleton.getPersistentDataContainer();
+        data.set(BetterHorseKeys.UNDEAD_SKELETON, PersistentDataType.BYTE, (byte) 1);
+        data.set(BetterHorseKeys.UNDEAD_ORIGINAL_TYPE, PersistentDataType.STRING, original.getType().name());
+        data.set(BetterHorseKeys.UNDEAD_ORIGINAL_HEALTH, PersistentDataType.DOUBLE, maxHealth);
+        data.set(BetterHorseKeys.UNDEAD_ORIGINAL_SPEED, PersistentDataType.DOUBLE, speed);
+        data.set(BetterHorseKeys.UNDEAD_ORIGINAL_JUMP, PersistentDataType.DOUBLE, jump);
+        if (original instanceof Horse h) {
+            data.set(BetterHorseKeys.UNDEAD_ORIGINAL_COLOR, PersistentDataType.STRING, h.getColor().name());
+            data.set(BetterHorseKeys.UNDEAD_ORIGINAL_STYLE, PersistentDataType.STRING, h.getStyle().name());
+        }
+        if (armor != null) data.set(BetterHorseKeys.UNDEAD_ARMOR_DATA, PersistentDataType.BYTE_ARRAY, armor.serializeAsBytes());
+        applyStats(skeleton, maxHealth, speed, jump);
+        skeleton.setHealth(maxHealth);
+        skeleton.setTamed(original.isTamed());
+        skeleton.setOwner(original.getOwner());
+        skeleton.getInventory().setSaddle(saddle == null ? null : saddle.clone());
+        if (original.getCustomName() != null) {
+            skeleton.setCustomName(original.getCustomName());
+            skeleton.setCustomNameVisible(original.isCustomNameVisible());
+        }
+        if (original.isLeashed()) original.getWorld().dropItemNaturally(original.getLocation(), new ItemStack(Material.LEAD));
+        original.eject();
+        original.remove();
+        remountNextTick(skeleton, passengers);
+    }
+
+    private void transformBack(SkeletonHorse skeleton) {
+        PersistentDataContainer data = skeleton.getPersistentDataContainer();
+        SupportedMountType type = SupportedMountType.fromName(data.get(BetterHorseKeys.UNDEAD_ORIGINAL_TYPE, PersistentDataType.STRING)).orElse(SupportedMountType.HORSE);
+        List<Entity> passengers = List.copyOf(skeleton.getPassengers());
+        AbstractHorse restored = type.spawn(skeleton.getLocation());
+        copyBetterHorsesData(data, restored.getPersistentDataContainer());
+        cleanupUndeadKeys(restored.getPersistentDataContainer());
+        double maxHealth = data.getOrDefault(BetterHorseKeys.UNDEAD_ORIGINAL_HEALTH, PersistentDataType.DOUBLE, getAttribute(skeleton, AttributeResolver.generic("MAX_HEALTH"), 20.0));
+        applyStats(restored, maxHealth,
+                data.getOrDefault(BetterHorseKeys.UNDEAD_ORIGINAL_SPEED, PersistentDataType.DOUBLE, getAttribute(skeleton, AttributeResolver.generic("MOVEMENT_SPEED"), 0.2)),
+                data.getOrDefault(BetterHorseKeys.UNDEAD_ORIGINAL_JUMP, PersistentDataType.DOUBLE, getAttribute(skeleton, AttributeResolver.horseJumpStrength(), 0.7)));
+        restored.setHealth(maxHealth);
+        restored.setTamed(skeleton.isTamed());
+        restored.setOwner(skeleton.getOwner());
+        restored.getInventory().setSaddle(skeleton.getInventory().getSaddle());
+        if (restored instanceof Horse horse) {
+            setHorseVariant(horse, data.get(BetterHorseKeys.UNDEAD_ORIGINAL_COLOR, PersistentDataType.STRING), data.get(BetterHorseKeys.UNDEAD_ORIGINAL_STYLE, PersistentDataType.STRING));
+            ItemStack armor = readStoredArmor(data);
+            if (armor != null) HorseArmorUtils.setArmor(restored.getInventory(), armor);
+        }
+        if (skeleton.getCustomName() != null) {
+            restored.setCustomName(skeleton.getCustomName());
+            restored.setCustomNameVisible(skeleton.isCustomNameVisible());
+        }
+        if (plugin.getConfig().getBoolean("traits.undead.transform-back-animation", true)) {
+            restored.getWorld().spawnParticle(TraitParticleResolver.getTraitParticle("undead", Particle.SOUL), restored.getLocation().add(0, 1, 0), 40, .6, .7, .6, .03);
+            restored.getWorld().playSound(restored.getLocation(), Sound.ENTITY_SKELETON_HORSE_AMBIENT, 1f, .8f);
+        }
+        skeleton.eject();
+        skeleton.remove();
+        remountNextTick(restored, passengers);
+    }
+
+    private void remountNextTick(AbstractHorse mount, List<Entity> passengers) {
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            if (!mount.isValid()) return;
+            for (Entity passenger : passengers) {
+                if (passenger instanceof Player && passenger.isValid() && passenger.getVehicle() == null) mount.addPassenger(passenger);
+            }
+        });
+    }
+
+    private Material getTransformBackItem() {
+        try { return Material.valueOf(plugin.getConfig().getString("traits.undead.transform-back-item", "ENCHANTED_GOLDEN_APPLE").toUpperCase(Locale.ROOT)); }
+        catch (IllegalArgumentException ignored) { return Material.ENCHANTED_GOLDEN_APPLE; }
+    }
+    private boolean isUndeadSkeleton(AbstractHorse horse) { return horse.getPersistentDataContainer().has(BetterHorseKeys.UNDEAD_SKELETON, PersistentDataType.BYTE); }
+    private void applyStats(AbstractHorse horse, double health, double speed, double jump) { setAttribute(horse, AttributeResolver.generic("MAX_HEALTH"), health); setAttribute(horse, AttributeResolver.generic("MOVEMENT_SPEED"), speed); setAttribute(horse, AttributeResolver.horseJumpStrength(), jump); }
+    private double getAttribute(AbstractHorse horse, Attribute attribute, double fallback) { AttributeInstance instance = horse.getAttribute(attribute); return instance == null ? fallback : instance.getBaseValue(); }
+    private void setAttribute(AbstractHorse horse, Attribute attribute, double value) { AttributeInstance instance = horse.getAttribute(attribute); if (instance != null) instance.setBaseValue(value); }
+    private void copyBetterHorsesData(PersistentDataContainer from, PersistentDataContainer to) {
+        for (org.bukkit.NamespacedKey key : from.getKeys()) {
+            if (!key.getNamespace().equals(plugin.getName().toLowerCase(Locale.ROOT))) continue;
+            copyKey(from, to, key, PersistentDataType.STRING); copyKey(from, to, key, PersistentDataType.DOUBLE); copyKey(from, to, key, PersistentDataType.LONG); copyKey(from, to, key, PersistentDataType.INTEGER); copyKey(from, to, key, PersistentDataType.BYTE); copyKey(from, to, key, PersistentDataType.BYTE_ARRAY);
+        }
+    }
+    private <T, Z> void copyKey(PersistentDataContainer from, PersistentDataContainer to, org.bukkit.NamespacedKey key, PersistentDataType<T, Z> type) { if (from.has(key, type)) to.set(key, type, from.get(key, type)); }
+    private void cleanupUndeadKeys(PersistentDataContainer data) { data.remove(BetterHorseKeys.UNDEAD_SKELETON); data.remove(BetterHorseKeys.UNDEAD_ORIGINAL_TYPE); data.remove(BetterHorseKeys.UNDEAD_ORIGINAL_HEALTH); data.remove(BetterHorseKeys.UNDEAD_ORIGINAL_SPEED); data.remove(BetterHorseKeys.UNDEAD_ORIGINAL_JUMP); data.remove(BetterHorseKeys.UNDEAD_ORIGINAL_COLOR); data.remove(BetterHorseKeys.UNDEAD_ORIGINAL_STYLE); data.remove(BetterHorseKeys.UNDEAD_ARMOR_DATA); }
+    private ItemStack readStoredArmor(PersistentDataContainer data) { byte[] bytes = data.get(BetterHorseKeys.UNDEAD_ARMOR_DATA, PersistentDataType.BYTE_ARRAY); if (bytes == null || bytes.length == 0) return null; try { return ItemStack.deserializeBytes(bytes); } catch (Exception ignored) { return null; } }
+    private void setHorseVariant(Horse horse, String color, String style) { try { if (color != null) horse.setColor(Horse.Color.valueOf(color)); } catch (IllegalArgumentException ignored) {} try { if (style != null) horse.setStyle(Horse.Style.valueOf(style)); } catch (IllegalArgumentException ignored) {} }
+}

--- a/BetterHorses/src/main/resources/config.yml
+++ b/BetterHorses/src/main/resources/config.yml
@@ -273,6 +273,14 @@ traits:
     cooldown: 30
     duration: 10
 
+
+  undead:
+    enabled: true
+    chance: 0.01
+    particle: SOUL
+    transform-back-item: ENCHANTED_GOLDEN_APPLE
+    transform-back-animation: true
+
   heavenhooves:
     enabled: true
     chance: 0.001 # 0.1%


### PR DESCRIPTION
### Motivation
- Implement an "Undead" passive trait so traited mounts do not immediately die but transform into a skeleton horse and can be restored by feeding a configurable item. 

### Description
- Add a new listener `UndeadTraitListener` that intercepts fatal damage on supported `AbstractHorse` mounts with the `undead` trait, cancels death, spawns a `SkeletonHorse`, and transfers PDC/ownership/stats/saddle/variant/rider data. 
- Persist trait metadata with new keys added to `BetterHorseKeys`: `UNDEAD_SKELETON`, `UNDEAD_ORIGINAL_TYPE`, `UNDEAD_ORIGINAL_HEALTH`, `UNDEAD_ORIGINAL_SPEED`, `UNDEAD_ORIGINAL_JUMP`, `UNDEAD_ORIGINAL_COLOR`, `UNDEAD_ORIGINAL_STYLE`, and `UNDEAD_ARMOR_DATA`, and copy necessary BetterHorses PDC data between entities. 
- Provide transform-back behavior triggered by feeding the configured item (default `ENCHANTED_GOLDEN_APPLE`) which restores original mount type/form, stats, armor (serialized/deserialized to preserve meta), owner/tame state, saddle, horse variant, and remounts players on the next tick; optionally plays a particle/sound animation controlled by `traits.undead.transform-back-animation`. 
- Preserve armor enchants/meta by serializing the `ItemStack` into the skeleton PDC and restoring it when transforming back, and drop stored armor when an Undead skeleton dies. 
- Register the listener only when `traits.undead.enabled` is enabled and add the required config section at `traits.undead` with `enabled`, `chance`, `particle`, `transform-back-item`, and `transform-back-animation`. 
- Use safe checks for supported mount types and attribute resolution via the existing `AttributeResolver` and `HorseArmorUtils`, and perform remounting on the next tick to avoid passenger timing issues.

### Testing
- Attempted to compile Java sources with `./gradlew compileJava` (invoked with `JAVA_HOME=/root/.local/share/mise/installs/java/21.0.2`), but Gradle failed during dependency resolution because the configured Maven repositories returned HTTP 403 errors for compile-time dependencies (Paper API / ProtocolLib / PlaceholderAPI), so a full compile could not be completed. 
- No automated unit tests exist for this change and no other automated test run completed due to the dependency resolution failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4008f96908832b9818ff718a50eecf)