### PR TITLE
Undead trait: preserve exact stats, prevent re-revive, persist PDC and drop stored armor

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
@@ -25,6 +25,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Horse;
 import org.bukkit.entity.ChestedHorse;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.SkeletonHorse;
 import org.bukkit.inventory.AbstractHorseInventory;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -195,13 +196,14 @@ public class BetterHorsesAPI {
                 : null;
 
         int growthStage = storedStage != null ? storedStage : 10;
-        SupportedMountType mountType = SupportedMountType.fromNameOrDefault(mountTypeName);
+        boolean undeadSkeleton = data.has(BetterHorseKeys.UNDEAD_SKELETON, PersistentDataType.BYTE);
+        SupportedMountType mountType = undeadSkeleton ? SupportedMountType.SKELETON_HORSE : SupportedMountType.fromNameOrDefault(mountTypeName);
 
         if (health == null || speed == null || jump == null || gender == null) {
             return null;
         }
 
-        if (!mountType.isEnabled(BetterHorses.getInstance().getConfig())) {
+        if (!undeadSkeleton && !mountType.isEnabled(BetterHorses.getInstance().getConfig())) {
             return null;
         }
 
@@ -261,6 +263,7 @@ public class BetterHorsesAPI {
         horseData.set(BetterHorseKeys.GENDER, PersistentDataType.STRING, gender);
         horseData.set(BetterHorseKeys.MOUNT_TYPE, PersistentDataType.STRING, mountType.getEntityType().name());
         copyTextureData(data, horseData);
+        copyUndeadData(data, horseData);
 
         if (trait != null && !trait.isBlank()) {
             horseData.set(BetterHorseKeys.TRAIT, PersistentDataType.STRING, trait);
@@ -277,7 +280,7 @@ public class BetterHorsesAPI {
             horse.setCustomNameVisible(true);
         }
 
-        if (horse instanceof Horse h) {
+        if (!undeadSkeleton && horse instanceof Horse h) {
             try {
                 h.setStyle(Horse.Style.valueOf(styleStr));
                 h.setColor(Horse.Color.valueOf(colorStr));
@@ -288,7 +291,7 @@ public class BetterHorsesAPI {
             horse.getInventory().setSaddle(new ItemStack(Material.valueOf(saddleStr)));
         }
         restoreChestContents(horse, chested != null && chested == (byte) 1, chestContents);
-        if (armorStr != null) {
+        if (!undeadSkeleton && armorStr != null) {
             ItemStack armorItem = restoreArmorItem(armorStr, armorData);
             if (armorItem != null) {
                 HorseArmorUtils.setArmor(horse.getInventory(), armorItem);
@@ -303,7 +306,10 @@ public class BetterHorsesAPI {
         LanguageManager lang = plugin.getLang();
         PersistentDataContainer data = horse.getPersistentDataContainer();
 
-        SupportedMountType mountType = SupportedMountType.fromEntity(horse)
+        boolean undeadSkeleton = horse instanceof SkeletonHorse && data.has(BetterHorseKeys.UNDEAD_SKELETON, PersistentDataType.BYTE);
+        SupportedMountType mountType = undeadSkeleton
+                ? SupportedMountType.SKELETON_HORSE
+                : SupportedMountType.fromEntity(horse)
                 .filter(type -> type.isEnabled(plugin.getConfig()))
                 .orElse(null);
         if (mountType == null) return null;
@@ -407,6 +413,7 @@ public class BetterHorsesAPI {
         itemData.set(BetterHorseKeys.COLOR, PersistentDataType.STRING, color.name());
         itemData.set(BetterHorseKeys.GROWTH_STAGE, PersistentDataType.INTEGER, growthStage);
         itemData.set(BetterHorseKeys.MOUNT_TYPE, PersistentDataType.STRING, mountType.getEntityType().name());
+        copyUndeadData(data, itemData);
         if (trait != null) itemData.set(traitKey, PersistentDataType.STRING, trait.toLowerCase());
         if (isNeutered) itemData.set(neuterKey, PersistentDataType.BYTE, (byte) 1);
         if (cooldown != null) itemData.set(BetterHorseKeys.COOLDOWN, PersistentDataType.LONG, cooldown);
@@ -528,6 +535,23 @@ public class BetterHorsesAPI {
                 data.get(BetterHorseKeys.TEXTURE_CIT_STRING, PersistentDataType.STRING),
                 data.get(BetterHorseKeys.TEXTURE_MODEL_STRING, PersistentDataType.STRING)
         );
+    }
+
+    private static void copyUndeadData(PersistentDataContainer source, PersistentDataContainer target) {
+        copyPdcKey(source, target, BetterHorseKeys.UNDEAD_SKELETON, PersistentDataType.BYTE);
+        copyPdcKey(source, target, BetterHorseKeys.UNDEAD_ORIGINAL_TYPE, PersistentDataType.STRING);
+        copyPdcKey(source, target, BetterHorseKeys.UNDEAD_ORIGINAL_HEALTH, PersistentDataType.DOUBLE);
+        copyPdcKey(source, target, BetterHorseKeys.UNDEAD_ORIGINAL_SPEED, PersistentDataType.DOUBLE);
+        copyPdcKey(source, target, BetterHorseKeys.UNDEAD_ORIGINAL_JUMP, PersistentDataType.DOUBLE);
+        copyPdcKey(source, target, BetterHorseKeys.UNDEAD_ORIGINAL_COLOR, PersistentDataType.STRING);
+        copyPdcKey(source, target, BetterHorseKeys.UNDEAD_ORIGINAL_STYLE, PersistentDataType.STRING);
+        copyPdcKey(source, target, BetterHorseKeys.UNDEAD_ARMOR_DATA, PersistentDataType.BYTE_ARRAY);
+    }
+
+    private static <T, Z> void copyPdcKey(PersistentDataContainer source, PersistentDataContainer target, NamespacedKey key, PersistentDataType<T, Z> type) {
+        if (source.has(key, type)) {
+            target.set(key, type, source.get(key, type));
+        }
     }
 
     private static void copyTextureData(PersistentDataContainer source, PersistentDataContainer target) {

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RightClickListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RightClickListener.java
@@ -74,7 +74,9 @@ public class RightClickListener implements Listener {
         }
 
         BetterHorsesAPI.callSpawnEvent(horse, item.clone(), BetterHorseSpawnEvent.SpawnCause.ITEM);
-        TrainingManager.recalculateAndApplyBonuses(horse);
+        if (!horse.getPersistentDataContainer().has(BetterHorseKeys.UNDEAD_SKELETON, PersistentDataType.BYTE)) {
+            TrainingManager.recalculateAndApplyBonuses(horse);
+        }
 
         item.setAmount(hasStoredChest && item.getAmount() > 1 ? 0 : item.getAmount() - 1);
         lang.sendFormatted(player, "messages.horse-respawned", "%mount%", mountName);

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/UndeadTraitListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/UndeadTraitListener.java
@@ -39,7 +39,7 @@ public class UndeadTraitListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onFatalDamage(EntityDamageEvent event) {
         if (!(event.getEntity() instanceof AbstractHorse horse)) return;
-        if (horse instanceof SkeletonHorse && isUndeadSkeleton(horse)) return;
+        if (horse instanceof SkeletonHorse) return;
         if (!SupportedMountType.isSupported(horse)) return;
         if (!TRAIT.equalsIgnoreCase(horse.getPersistentDataContainer().get(BetterHorseKeys.TRAIT, PersistentDataType.STRING))) return;
         if (event.getFinalDamage() < horse.getHealth()) return;
@@ -63,8 +63,11 @@ public class UndeadTraitListener implements Listener {
     public void onUndeadSkeletonDeath(EntityDeathEvent event) {
         if (!(event.getEntity() instanceof SkeletonHorse skeleton)) return;
         if (!isUndeadSkeleton(skeleton)) return;
-        ItemStack armor = readStoredArmor(skeleton.getPersistentDataContainer());
-        if (armor != null) event.getDrops().add(armor);
+        PersistentDataContainer data = skeleton.getPersistentDataContainer();
+        ItemStack armor = readStoredArmor(data);
+        if (armor == null) return;
+        data.remove(BetterHorseKeys.UNDEAD_ARMOR_DATA);
+        skeleton.getWorld().dropItemNaturally(skeleton.getLocation(), armor);
     }
 
     private void transformToSkeleton(AbstractHorse original) {
@@ -153,7 +156,7 @@ public class UndeadTraitListener implements Listener {
     }
     private boolean isUndeadSkeleton(AbstractHorse horse) { return horse.getPersistentDataContainer().has(BetterHorseKeys.UNDEAD_SKELETON, PersistentDataType.BYTE); }
     private void applyStats(AbstractHorse horse, double health, double speed, double jump) { setAttribute(horse, AttributeResolver.generic("MAX_HEALTH"), health); setAttribute(horse, AttributeResolver.generic("MOVEMENT_SPEED"), speed); setAttribute(horse, AttributeResolver.horseJumpStrength(), jump); }
-    private double getAttribute(AbstractHorse horse, Attribute attribute, double fallback) { AttributeInstance instance = horse.getAttribute(attribute); return instance == null ? fallback : instance.getBaseValue(); }
+    private double getAttribute(AbstractHorse horse, Attribute attribute, double fallback) { AttributeInstance instance = horse.getAttribute(attribute); return instance == null ? fallback : instance.getValue(); }
     private void setAttribute(AbstractHorse horse, Attribute attribute, double value) { AttributeInstance instance = horse.getAttribute(attribute); if (instance != null) instance.setBaseValue(value); }
     private void copyBetterHorsesData(PersistentDataContainer from, PersistentDataContainer to) {
         for (org.bukkit.NamespacedKey key : from.getKeys()) {


### PR DESCRIPTION
### Motivation
- Ensure an Undead trait horse keeps the exact final effective movement speed, jump strength, and max health after transforming into a skeleton horse and that those values are not recomputed or rounded. 
- Prevent already-transformed skeleton horses from entering the Undead revive path and ensure a transformed skeleton horse dies permanently. 
- Ensure stored armor is preserved and dropped once on final undead death and that undead metadata survives horse->item->horse roundtrips so respawned undead skeletons remain restorable.

### Description
- Copy the entity’s final effective attribute values by reading `AttributeInstance.getValue()` and writing them unchanged to the skeleton when transforming, and apply them without recalculation. 
- Skip the revive logic for any `SkeletonHorse` in the fatal-damage listener so skeletons (including transformed Undead skeletons) cannot trigger a second transform. 
- Persist Undead metadata across serialization by adding `copyUndeadData(...)` in the API and propagating `UNDEAD_*` PDC keys into the horse item and back into the respawned entity. 
- On undead skeleton death, read the stored armor bytes from PDC, clear the `UNDEAD_ARMOR_DATA` key to avoid duplication, and drop the preserved `ItemStack` naturally at the death location. 
- When restoring from an item, detect the `UNDEAD_SKELETON` flag and spawn a skeleton-horse mount and skip normal horse-only variant/armor restore and training-recalculation paths to avoid altering stored undead stats.

### Testing
- `git diff --check` was run and returned clean results. 
- Project tests were attempted with `./gradlew test` (and with `JAVA_HOME` override), but the build failed to fetch external dependencies (Paper API / ProtocolLib / PlaceholderAPI) from configured repositories (403), preventing full automated test execution. 
- Static/manual verification performed via code inspection and targeted run attempts to ensure the new PDC copy, attribute reads, armor-drop, and revive-avoidance logic are present and consistent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a400fc1ff40832bbc89c33d9a589eb9)