### PR TITLE
Add trample damage event gate

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/TrampleListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/TrampleListener.java
@@ -113,7 +113,14 @@ public class TrampleListener implements Listener {
                 continue;
             }
 
-            applyTrample(rider, horseLocation, (LivingEntity) entity, config, currentTick);
+            LivingEntity target = (LivingEntity) entity;
+            EntityDamageByEntityEvent damageEvent = createTrampleDamageEvent(rider, target, config);
+            Bukkit.getPluginManager().callEvent(damageEvent);
+            if (damageEvent.isCancelled()) {
+                continue;
+            }
+
+            applyTrample(rider, horseLocation, target, config, currentTick, damageEvent);
         }
     }
 
@@ -152,20 +159,18 @@ public class TrampleListener implements Listener {
         return dot >= minimumDot;
     }
 
-    private void applyTrample(Player rider, Location horseLocation, LivingEntity target, FileConfiguration config, long currentTick) {
+    private EntityDamageByEntityEvent createTrampleDamageEvent(Player rider, LivingEntity target, FileConfiguration config) {
         double damage = Math.max(0.0, config.getDouble("trample.damage", 4.0));
-        double knockbackStrength = Math.max(0.0, config.getDouble("trample.knockback", 1.2));
-
-        EntityDamageByEntityEvent damageEvent = new EntityDamageByEntityEvent(
+        return new EntityDamageByEntityEvent(
                 rider,
                 target,
                 EntityDamageEvent.DamageCause.ENTITY_ATTACK,
                 damage
         );
-        Bukkit.getPluginManager().callEvent(damageEvent);
-        if (damageEvent.isCancelled()) {
-            return;
-        }
+    }
+
+    private void applyTrample(Player rider, Location horseLocation, LivingEntity target, FileConfiguration config, long currentTick, EntityDamageByEntityEvent damageEvent) {
+        double knockbackStrength = Math.max(0.0, config.getDouble("trample.knockback", 1.2));
 
         int cooldownTicks = Math.max(0, config.getInt("trample.cooldown-ticks", 20));
         targetCooldowns.put(target.getUniqueId(), currentTick + cooldownTicks);


### PR DESCRIPTION
### Motivation
- Allow other plugins or server logic to cancel or modify a trample hit by firing an `EntityDamageByEntityEvent` from the rider to the attempted trample target and skip trample effects if cancelled.

### Description
- Create `createTrampleDamageEvent(Player, LivingEntity, FileConfiguration)` to build the trample `EntityDamageByEntityEvent` using configured damage.
- Fire the damage event before applying trample and `continue` if the event is cancelled so no damage or knockback is applied.
- Change `applyTrample` to accept the approved `EntityDamageByEntityEvent` and use its `getDamage()` value when applying damage while preserving cooldown and knockback logic.
- Update call sites to construct, call, and gate on the event prior to invoking the trample application.

### Testing
- `git diff --check` was executed and returned no problems.
- `./gradlew test` run with the default environment initially failed due to a Java class file version mismatch error from the environment.
- `JAVA_HOME=/root/.local/share/mise/installs/java/21.0.2 ./gradlew test` was attempted but the build failed because remote Maven repositories returned HTTP 403 when resolving compile-time dependencies, preventing full test execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a402e179f7c832b86da28f9f8cc1160)