### PR TITLE
Add PermissionUtils and enforce per-feature permissions across commands and listeners

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/BetterHorses.java
@@ -243,6 +243,7 @@ public class BetterHorses extends JavaPlugin {
         pluginManager.registerEvents(new HorseFeedListener(), this);
         pluginManager.registerEvents(new HorseItemBlockerListener(), this);
         pluginManager.registerEvents(new HorseMountListener(), this);
+        pluginManager.registerEvents(new HorsePermissionListener(), this);
 
         debugLog("LISTENER", "REGISTER_BASE", true, "Registered core horse listeners.");
 

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseCommand.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseCommand.java
@@ -2,6 +2,7 @@ package me.luisgamedev.betterhorses.commands;
 
 import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.language.LanguageManager;
+import me.luisgamedev.betterhorses.utils.PermissionUtils;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -49,19 +50,19 @@ public class HorseCommand implements CommandExecutor {
 
         switch (subcommand) {
             case "spawn":
-                if (!player.hasPermission("betterhorses.base")) {
+                if (!player.hasPermission(PermissionUtils.SPAWN_COMMAND)) {
                     lang.sendFormatted(player, "messages.insufficient-permission", "%command%", "/horse spawn");
                     plugin.debugLog("HORSE_COMMAND", "SPAWN_PERMISSION", false,
-                            "Player " + player.getName() + " lacks betterhorses.base");
+                            "Player " + player.getName() + " lacks betterhorses.spawn.command");
                     return true;
                 }
                 return RespawnCommand.spawnHorseFromItem(player);
 
             case "despawn":
-                if (!player.hasPermission("betterhorses.base")) {
+                if (!player.hasPermission(PermissionUtils.DESPAWN)) {
                     lang.sendFormatted(player, "messages.insufficient-permission", "%command%", "/horse despawn");
                     plugin.debugLog("HORSE_COMMAND", "DESPAWN_PERMISSION", false,
-                            "Player " + player.getName() + " lacks betterhorses.base");
+                            "Player " + player.getName() + " lacks betterhorses.despawn");
                     return true;
                 }
                 return DespawnCommand.despawnHorseToItem(player);
@@ -76,6 +77,12 @@ public class HorseCommand implements CommandExecutor {
                 return HorseNeuterCommand.handle(player);
 
             case "info":
+                if (!player.hasPermission(PermissionUtils.INFO)) {
+                    lang.sendFormatted(player, "messages.insufficient-permission", "%command%", "/horse info");
+                    plugin.debugLog("HORSE_COMMAND", "INFO_PERMISSION", false,
+                            "Player " + player.getName() + " lacks betterhorses.info");
+                    return true;
+                }
                 if (!plugin.isDebugModeEnabled()) {
                     lang.send(player, "messages.unknown-subcommand");
                     plugin.debugLog("HORSE_COMMAND", "INFO_DEBUG_DISABLED", false,

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseCommandCompleter.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseCommandCompleter.java
@@ -1,12 +1,12 @@
 package me.luisgamedev.betterhorses.commands;
 
 import me.luisgamedev.betterhorses.BetterHorses;
+import me.luisgamedev.betterhorses.utils.PermissionUtils;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 public class HorseCommandCompleter implements TabCompleter {
@@ -14,13 +14,18 @@ public class HorseCommandCompleter implements TabCompleter {
     @Override
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
         if (args.length == 1) {
-            List<String> suggestions = new ArrayList<>(Arrays.asList("spawn", "despawn", "neuter"));
+            List<String> suggestions = new ArrayList<>();
+            if (sender.hasPermission(PermissionUtils.SPAWN_COMMAND)) suggestions.add("spawn");
+            if (sender.hasPermission(PermissionUtils.DESPAWN)) suggestions.add("despawn");
+            if (sender.hasPermission("betterhorses.neuter")) suggestions.add("neuter");
             if (sender.hasPermission("betterhorses.reload")) {
                 suggestions.add("reload");
             }
-            if (BetterHorses.getInstance().isDebugModeEnabled()) {
+            if (BetterHorses.getInstance().isDebugModeEnabled() && sender.hasPermission(PermissionUtils.INFO)) {
                 suggestions.add("info");
             }
+            String current = args[0].toLowerCase();
+            suggestions.removeIf(suggestion -> !suggestion.toLowerCase().startsWith(current));
             return suggestions;
         }
         return List.of();

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseCreateTabCompleter.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/commands/HorseCreateTabCompleter.java
@@ -17,6 +17,10 @@ public class HorseCreateTabCompleter implements TabCompleter {
 
     @Override
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (!sender.hasPermission("betterhorses.create")) {
+            return Collections.emptyList();
+        }
+
         List<String> suggestions = new ArrayList<>();
 
         switch (args.length) {

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseBreedListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseBreedListener.java
@@ -4,6 +4,7 @@ import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.api.BetterHorseKeys;
 import me.luisgamedev.betterhorses.api.events.BetterHorseBreedEvent;
 import me.luisgamedev.betterhorses.utils.MountConfig;
+import me.luisgamedev.betterhorses.utils.PermissionUtils;
 import me.luisgamedev.betterhorses.utils.SupportedMountType;
 import org.bukkit.Bukkit;
 import me.luisgamedev.betterhorses.utils.AttributeResolver;
@@ -12,6 +13,8 @@ import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.AbstractHorse;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityBreedEvent;
@@ -33,7 +36,13 @@ public class HorseBreedListener implements Listener {
         FileConfiguration config = BetterHorses.getInstance().getConfig();
         if (!mountType.isEnabled(config)) return;
 
-        if (isNeutered(horse) || isOnBreedingCooldown(horse, config)) {
+        HumanEntity feeder = event.getHumanEntity();
+        if (feeder instanceof Player player && !player.hasPermission(PermissionUtils.BREED)) {
+            event.setCancelled(true);
+            return;
+        }
+
+        if (isNeutered(horse) || isOnBreedingCooldown(horse, config, feeder instanceof Player player ? player : null)) {
             event.setCancelled(true);
             return;
         }
@@ -58,6 +67,12 @@ public class HorseBreedListener implements Listener {
         if (childType == null || fatherType == null || motherType == null) return;
         if (!childType.equals(fatherType) || !childType.equals(motherType)) return;
         if (!childType.isEnabled(config)) return;
+
+        Player breeder = event.getBreeder() instanceof Player player ? player : null;
+        if (breeder != null && !breeder.hasPermission(PermissionUtils.BREED)) {
+            event.setCancelled(true);
+            return;
+        }
 
         father.setAge(0);
         mother.setAge(0);
@@ -102,7 +117,10 @@ public class HorseBreedListener implements Listener {
 
                     double chance = tSec.getDouble("chance", 0);
                     if (Math.random() < chance) {
-                        selectedTrait = trait.toLowerCase();
+                        String candidateTrait = trait.toLowerCase();
+                        if (breeder == null || PermissionUtils.canReceiveTrait(breeder, candidateTrait)) {
+                            selectedTrait = candidateTrait;
+                        }
                         break;
                     }
                 }
@@ -147,10 +165,11 @@ public class HorseBreedListener implements Listener {
         mother.setAge(0);
     }
 
-    private boolean isOnBreedingCooldown(AbstractHorse horse, FileConfiguration config) {
+    private boolean isOnBreedingCooldown(AbstractHorse horse, FileConfiguration config, Player breeder) {
         PersistentDataContainer data = horse.getPersistentDataContainer();
         Long last = data.get(BetterHorseKeys.COOLDOWN, PersistentDataType.LONG);
         if (last == null) return false;
+        if (breeder != null && breeder.hasPermission(PermissionUtils.COOLDOWN_BYPASS)) return false;
 
         String gender = getGender(horse);
         if ("male".equalsIgnoreCase(gender) && config.getBoolean("settings.male-ignore-cooldown")) {

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseFeedListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseFeedListener.java
@@ -3,6 +3,7 @@ package me.luisgamedev.betterhorses.listeners;
 import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.api.BetterHorseKeys;
 import me.luisgamedev.betterhorses.training.TrainingManager;
+import me.luisgamedev.betterhorses.utils.PermissionUtils;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -38,6 +39,11 @@ public class HorseFeedListener implements Listener {
 
         if (!isFood) return;
 
+        if (!player.hasPermission(PermissionUtils.FEED)) {
+            event.setCancelled(true);
+            return;
+        }
+
         final double feedingTrainingValue = TrainingManager.getFoodTrainingValue(type);
         final FileConfiguration config = BetterHorses.getInstance().getConfig();
 
@@ -52,14 +58,14 @@ public class HorseFeedListener implements Listener {
         final PersistentDataContainer data = horse.getPersistentDataContainer();
 
         final long cooldownSeconds = config.getLong("settings.breeding-cooldown", 0L);
-        if (cooldownSeconds > 0L) {
+        if (cooldownSeconds > 0L && !player.hasPermission(PermissionUtils.COOLDOWN_BYPASS)) {
             final long cooldownMillis = cooldownSeconds * 1000L;
 
             if (config.getBoolean("settings.male-ignore-cooldown", false)) {
                 final String gender = data.getOrDefault(BetterHorseKeys.GENDER, PersistentDataType.STRING, "UNKNOWN");
                 if ("male".equalsIgnoreCase(gender)) {
                     horse.setAge(0);
-                    tryAddFeedingTraining(horse, data, config, feedingTrainingValue, now);
+                    tryAddFeedingTraining(horse, data, config, player.hasPermission(PermissionUtils.TRAINING) ? feedingTrainingValue : 0.0, now);
                     return;
                 }
             }
@@ -80,7 +86,7 @@ public class HorseFeedListener implements Listener {
         }
 
         if (!event.isCancelled()) {
-            tryAddFeedingTraining(horse, data, config, feedingTrainingValue, now);
+            tryAddFeedingTraining(horse, data, config, player.hasPermission(PermissionUtils.TRAINING) ? feedingTrainingValue : 0.0, now);
         }
     }
 

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseJumpListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseJumpListener.java
@@ -3,6 +3,7 @@ package me.luisgamedev.betterhorses.listeners;
 import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.language.LanguageManager;
 import me.luisgamedev.betterhorses.traits.TraitRegistry;
+import me.luisgamedev.betterhorses.utils.PermissionUtils;
 import me.luisgamedev.betterhorses.utils.SupportedMountType;
 import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -31,9 +32,9 @@ public class HorseJumpListener implements Listener {
     public void onHorseJump(HorseJumpEvent event) {
         if (!(event.getEntity() instanceof AbstractHorse horse)) return;
         if (!SupportedMountType.isSupported(horse)) return;
-        if (hasHeavenHoovesTrait(horse)) {
+        if (hasHeavenHoovesTrait(horse) && !horse.getPassengers().isEmpty()) {
             Entity rider = horse.getPassengers().get(0);
-            if (rider instanceof Player player) {
+            if (rider instanceof Player player && PermissionUtils.canUseTrait(player, "heavenhooves")) {
                 TraitRegistry.activateHeavenHooves(player, horse, event);
             }
         }
@@ -64,7 +65,7 @@ public class HorseJumpListener implements Listener {
                         if (horse.isOnGround()) {
                             if (!horse.getPassengers().isEmpty()) {
                                 Entity rider = horse.getPassengers().get(0);
-                                if (rider instanceof Player player) {
+                                if (rider instanceof Player player && PermissionUtils.canUseTrait(player, "skyburst")) {
                                     TraitRegistry.activateSkyburst(player, horse);
                                 }
                             }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseMountListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseMountListener.java
@@ -1,22 +1,27 @@
 package me.luisgamedev.betterhorses.listeners;
 
 import me.luisgamedev.betterhorses.BetterHorses;
+import me.luisgamedev.betterhorses.utils.PermissionUtils;
 import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.entity.EntityMountEvent;
 import org.bukkit.persistence.PersistentDataType;
 
 public class HorseMountListener implements Listener {
 
-    @EventHandler
-    public void onHorseMount(PlayerInteractEntityEvent event) {
+    @EventHandler(ignoreCancelled = true)
+    public void onHorseMount(EntityMountEvent event) {
+        if (!(event.getMount() instanceof AbstractHorse horse)) return;
+        if (!(event.getEntity() instanceof Player player)) return;
 
-        if (!(event.getRightClicked() instanceof AbstractHorse horse)) return;
-        if (!(event.getPlayer() instanceof Player player)) return;
+        if (!player.hasPermission(PermissionUtils.MOUNT)) {
+            event.setCancelled(true);
+            return;
+        }
 
         if (player.hasPermission("betterhorses.bypass")) return;
 

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorsePermissionListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorsePermissionListener.java
@@ -1,0 +1,37 @@
+package me.luisgamedev.betterhorses.listeners;
+
+import me.luisgamedev.betterhorses.utils.PermissionUtils;
+import me.luisgamedev.betterhorses.utils.SupportedMountType;
+import org.bukkit.entity.AbstractHorse;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityTameEvent;
+import org.bukkit.event.player.PlayerLeashEntityEvent;
+
+public class HorsePermissionListener implements Listener {
+
+    @EventHandler(ignoreCancelled = true)
+    public void onTame(EntityTameEvent event) {
+        if (!(event.getEntity() instanceof AbstractHorse horse)) return;
+        if (!SupportedMountType.isSupported(horse)) return;
+        if (!(event.getOwner() instanceof Player player)) return;
+
+        if (!player.hasPermission(PermissionUtils.TAME)) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onLeash(PlayerLeashEntityEvent event) {
+        Entity entity = event.getEntity();
+        if (!(entity instanceof AbstractHorse horse)) return;
+        if (!SupportedMountType.isSupported(horse)) return;
+
+        Player player = event.getPlayer();
+        if (!player.hasPermission(PermissionUtils.LEASH)) {
+            event.setCancelled(true);
+        }
+    }
+}

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseTrainingBrushingListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseTrainingBrushingListener.java
@@ -3,6 +3,7 @@ package me.luisgamedev.betterhorses.listeners;
 import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.api.BetterHorseKeys;
 import me.luisgamedev.betterhorses.training.TrainingManager;
+import me.luisgamedev.betterhorses.utils.PermissionUtils;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -25,6 +26,8 @@ public class HorseTrainingBrushingListener implements Listener {
         if (!TrainingManager.isTrainingEnabled(config) || !TrainingManager.isCategoryEnabled(config, "brushing")) return;
 
         Player player = event.getPlayer();
+        if (!player.hasPermission(PermissionUtils.TRAINING)) return;
+
         ItemStack item = player.getInventory().getItem(event.getHand());
         if (item == null || item.getType() == Material.AIR) return;
 

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseTrainingRidingListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/HorseTrainingRidingListener.java
@@ -1,6 +1,7 @@
 package me.luisgamedev.betterhorses.listeners;
 
 import me.luisgamedev.betterhorses.training.TrainingManager;
+import me.luisgamedev.betterhorses.utils.PermissionUtils;
 import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -13,6 +14,7 @@ public class HorseTrainingRidingListener implements Listener {
     public void onMove(PlayerMoveEvent event) {
         if(event.isCancelled()) return;
         Player player = event.getPlayer();
+        if (!player.hasPermission(PermissionUtils.TRAINING)) return;
         if (!(player.getVehicle() instanceof AbstractHorse horse)) return;
         if (event.getTo() == null || event.getFrom().getWorld() != event.getTo().getWorld()) return;
 

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/MountedDamageBoostListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/MountedDamageBoostListener.java
@@ -1,6 +1,7 @@
 package me.luisgamedev.betterhorses.listeners;
 
 import me.luisgamedev.betterhorses.BetterHorses;
+import me.luisgamedev.betterhorses.utils.PermissionUtils;
 import me.luisgamedev.betterhorses.utils.SupportedMountType;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Entity;
@@ -17,6 +18,7 @@ public class MountedDamageBoostListener implements Listener {
     public void onMountedDamage(EntityDamageByEntityEvent event) {
         Entity damager = event.getDamager();
         if (!(damager instanceof Player player)) return;
+        if (!player.hasPermission(PermissionUtils.RIDER_DAMAGE_BOOST)) return;
 
         Entity vehicle = player.getVehicle();
         if (!(vehicle instanceof AbstractHorse mount) || !SupportedMountType.isSupported(mount)) return;

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/PassiveTraitListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/PassiveTraitListener.java
@@ -2,6 +2,7 @@ package me.luisgamedev.betterhorses.listeners;
 
 import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.traits.TraitRegistry;
+import me.luisgamedev.betterhorses.utils.PermissionUtils;
 import me.luisgamedev.betterhorses.utils.SupportedMountType;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.AbstractHorse;
@@ -25,6 +26,7 @@ public class PassiveTraitListener implements Listener {
         if (!data.has(traitKey, PersistentDataType.STRING)) return;
 
         String trait = data.get(traitKey, PersistentDataType.STRING).toLowerCase();
+        if (!PermissionUtils.canUseTrait(player, trait)) return;
 
         switch (trait) {
             case "frosthooves":

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RiderInvulnerableListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RiderInvulnerableListener.java
@@ -1,6 +1,7 @@
 package me.luisgamedev.betterhorses.listeners;
 
 import me.luisgamedev.betterhorses.BetterHorses;
+import me.luisgamedev.betterhorses.utils.PermissionUtils;
 import me.luisgamedev.betterhorses.utils.SupportedMountType;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Entity;
@@ -17,6 +18,7 @@ public class RiderInvulnerableListener implements Listener {
         Entity entity = event.getEntity();
 
         if (!(entity instanceof Player player)) return;
+        if (!player.hasPermission(PermissionUtils.RIDER_INVINCIBLE)) return;
 
         FileConfiguration config = BetterHorses.getInstance().getConfig();
         if (!config.getBoolean("settings.rider-invulnerable", false)) return;

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RightClickListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/RightClickListener.java
@@ -6,6 +6,7 @@ import me.luisgamedev.betterhorses.api.BetterHorsesAPI;
 import me.luisgamedev.betterhorses.api.events.BetterHorseSpawnEvent;
 import me.luisgamedev.betterhorses.language.LanguageManager;
 import me.luisgamedev.betterhorses.training.TrainingManager;
+import me.luisgamedev.betterhorses.utils.PermissionUtils;
 import me.luisgamedev.betterhorses.utils.SupportedMountType;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -33,8 +34,6 @@ public class RightClickListener implements Listener {
         Player player = event.getPlayer();
         ItemStack item = player.getInventory().getItemInMainHand();
         if (item == null || item.getType() == Material.AIR) return;
-        if (!player.hasPermission("betterhorses.base")) return;
-
         LanguageManager lang = BetterHorses.getInstance().getLang();
         FileConfiguration config = BetterHorses.getInstance().getConfig();
         if (!config.getBoolean("settings.allow-rightclick-spawn")) return;
@@ -44,6 +43,10 @@ public class RightClickListener implements Listener {
         if (expectedMaterial == null || !expectedMaterial.isItem()) expectedMaterial = Material.SADDLE;
 
         if (!item.hasItemMeta() || item.getType() != expectedMaterial) return;
+        if (!player.hasPermission(PermissionUtils.SPAWN_RIGHT_CLICK)) {
+            event.setCancelled(true);
+            return;
+        }
 
         ItemMeta meta = item.getItemMeta();
         TrainingManager.ensureTrainingData(meta.getPersistentDataContainer());

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/TraitActivationListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/TraitActivationListener.java
@@ -3,6 +3,7 @@ package me.luisgamedev.betterhorses.listeners;
 import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.api.events.BetterHorseAbilityUseEvent;
 import me.luisgamedev.betterhorses.traits.TraitRegistry;
+import me.luisgamedev.betterhorses.utils.PermissionUtils;
 import me.luisgamedev.betterhorses.utils.SupportedMountType;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
@@ -34,6 +35,10 @@ public class TraitActivationListener implements Listener {
 
         String trait = data.get(traitKey, PersistentDataType.STRING);
         if (trait == null) return;
+        if (!PermissionUtils.canUseTrait(player, trait)) {
+            event.setCancelled(true);
+            return;
+        }
 
         BetterHorseAbilityUseEvent abilityEvent = new BetterHorseAbilityUseEvent(player, mount, trait.toLowerCase());
         Bukkit.getPluginManager().callEvent(abilityEvent);
@@ -78,11 +83,6 @@ public class TraitActivationListener implements Listener {
         if (traitKey == null) {
             return "";
         }
-        return traitKey
-                .toLowerCase()
-                .replace("_", "")
-                .replace("-", "")
-                .replace(" ", "")
-                .trim();
+        return PermissionUtils.normalizeTraitKey(traitKey);
     }
 }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/TrampleListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/TrampleListener.java
@@ -1,6 +1,7 @@
 package me.luisgamedev.betterhorses.listeners;
 
 import me.luisgamedev.betterhorses.BetterHorses;
+import me.luisgamedev.betterhorses.utils.PermissionUtils;
 import me.luisgamedev.betterhorses.utils.SupportedMountType;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -57,6 +58,9 @@ public class TrampleListener implements Listener {
 
         for (Player rider : Bukkit.getOnlinePlayers()) {
             if (!(rider.getVehicle() instanceof AbstractHorse horse)) {
+                continue;
+            }
+            if (!rider.hasPermission(PermissionUtils.TRAMPLE)) {
                 continue;
             }
             SupportedMountType mountType = SupportedMountType.fromEntity(horse).orElse(null);

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/UndeadTraitListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/UndeadTraitListener.java
@@ -5,6 +5,7 @@ import me.luisgamedev.betterhorses.api.BetterHorseKeys;
 import me.luisgamedev.betterhorses.traits.TraitParticleResolver;
 import me.luisgamedev.betterhorses.utils.AttributeResolver;
 import me.luisgamedev.betterhorses.utils.HorseArmorUtils;
+import me.luisgamedev.betterhorses.utils.PermissionUtils;
 import me.luisgamedev.betterhorses.utils.SupportedMountType;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -43,6 +44,7 @@ public class UndeadTraitListener implements Listener {
         if (!SupportedMountType.isSupported(horse)) return;
         if (!TRAIT.equalsIgnoreCase(horse.getPersistentDataContainer().get(BetterHorseKeys.TRAIT, PersistentDataType.STRING))) return;
         if (event.getFinalDamage() < horse.getHealth()) return;
+        if (!canUseUndeadTrait(horse)) return;
         event.setCancelled(true);
         transformToSkeleton(horse);
     }
@@ -54,6 +56,7 @@ public class UndeadTraitListener implements Listener {
         if (!isUndeadSkeleton(skeleton)) return;
         ItemStack item = event.getPlayer().getInventory().getItem(event.getHand());
         if (item == null || item.getType() != getTransformBackItem()) return;
+        if (!PermissionUtils.canUseTrait(event.getPlayer(), TRAIT)) return;
         event.setCancelled(true);
         if (item.getAmount() > 1) item.setAmount(item.getAmount() - 1); else event.getPlayer().getInventory().setItem(event.getHand(), null);
         transformBack(skeleton);
@@ -68,6 +71,15 @@ public class UndeadTraitListener implements Listener {
         if (armor == null) return;
         data.remove(BetterHorseKeys.UNDEAD_ARMOR_DATA);
         skeleton.getWorld().dropItemNaturally(skeleton.getLocation(), armor);
+    }
+
+    private boolean canUseUndeadTrait(AbstractHorse horse) {
+        for (Entity passenger : horse.getPassengers()) {
+            if (passenger instanceof Player player) {
+                return PermissionUtils.canUseTrait(player, TRAIT);
+            }
+        }
+        return !(horse.getOwner() instanceof Player player) || PermissionUtils.canUseTrait(player, TRAIT);
     }
 
     private void transformToSkeleton(AbstractHorse original) {

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/PermissionUtils.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/PermissionUtils.java
@@ -1,0 +1,80 @@
+package me.luisgamedev.betterhorses.utils;
+
+import me.luisgamedev.betterhorses.BetterHorses;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.Locale;
+import java.util.Set;
+
+public final class PermissionUtils {
+    private static final Set<String> TRAIT_SPECIFIC_PERMISSIONS = Set.of(
+            "hellmare",
+            "fireheart",
+            "featherhooves",
+            "dashboost",
+            "kickback",
+            "ghosthorse",
+            "heavenhooves",
+            "undead"
+    );
+
+    private PermissionUtils() {
+    }
+
+    public static final String MOUNT = "betterhorses.mount";
+    public static final String FEED = "betterhorses.feed";
+    public static final String BREED = "betterhorses.breed";
+    public static final String TAME = "betterhorses.tame";
+    public static final String LEASH = "betterhorses.leash";
+    public static final String TRAMPLE = "betterhorses.trample";
+    public static final String SPAWN_RIGHT_CLICK = "betterhorses.spawn.rightclick";
+    public static final String TRAINING = "betterhorses.training";
+    public static final String COOLDOWN_BYPASS = "betterhorses.cooldown.bypass";
+    public static final String RIDER_INVINCIBLE = "betterhorses.rider.invincible";
+    public static final String RIDER_DAMAGE_BOOST = "betterhorses.rider.damageboost";
+    public static final String TRAIT_USE = "betterhorses.trait.use";
+    public static final String TRAIT_RECEIVE = "betterhorses.trait.receive";
+    public static final String INFO = "betterhorses.info";
+    public static final String SPAWN_COMMAND = "betterhorses.spawn.command";
+    public static final String DESPAWN = "betterhorses.despawn";
+
+    public static boolean has(CommandSender sender, String permission) {
+        return sender.hasPermission(permission);
+    }
+
+    public static boolean canUseTrait(Player player, String traitKey) {
+        if (!player.hasPermission(TRAIT_USE)) {
+            return false;
+        }
+        String normalized = normalizeTraitKey(traitKey);
+        return normalized.isEmpty()
+                || !TRAIT_SPECIFIC_PERMISSIONS.contains(normalized)
+                || player.hasPermission("betterhorses.trait." + normalized);
+    }
+
+    public static boolean canReceiveTrait(Player player, String traitKey) {
+        if (!player.hasPermission(TRAIT_RECEIVE)) {
+            return false;
+        }
+        String normalized = normalizeTraitKey(traitKey);
+        return normalized.isEmpty()
+                || !TRAIT_SPECIFIC_PERMISSIONS.contains(normalized)
+                || player.hasPermission("betterhorses.trait." + normalized);
+    }
+
+    public static void deny(Player player, String command) {
+        BetterHorses.getInstance().getLang().sendFormatted(player, "messages.insufficient-permission", "%command%", command);
+    }
+
+    public static String normalizeTraitKey(String traitKey) {
+        if (traitKey == null) {
+            return "";
+        }
+        return traitKey.toLowerCase(Locale.ROOT)
+                .replace("_", "")
+                .replace("-", "")
+                .replace(" ", "")
+                .trim();
+    }
+}

--- a/BetterHorses/src/main/resources/plugin.yml
+++ b/BetterHorses/src/main/resources/plugin.yml
@@ -15,6 +15,39 @@ commands:
     permission: betterhorses.create
 
 permissions:
+  betterhorses.*:
+    description: Grants access to all BetterHorses permissions
+    default: op
+    children:
+      betterhorses.mount: true
+      betterhorses.feed: true
+      betterhorses.breed: true
+      betterhorses.tame: true
+      betterhorses.leash: true
+      betterhorses.bypass: true
+      betterhorses.trample: true
+      betterhorses.spawn.rightclick: true
+      betterhorses.training: true
+      betterhorses.cooldown.bypass: true
+      betterhorses.rider.invincible: true
+      betterhorses.rider.damageboost: true
+      betterhorses.trait.use: true
+      betterhorses.trait.receive: true
+      betterhorses.trait.hellmare: true
+      betterhorses.trait.fireheart: true
+      betterhorses.trait.featherhooves: true
+      betterhorses.trait.dashboost: true
+      betterhorses.trait.kickback: true
+      betterhorses.trait.ghosthorse: true
+      betterhorses.trait.heavenhooves: true
+      betterhorses.trait.undead: true
+      betterhorses.info: true
+      betterhorses.neuter: true
+      betterhorses.create: true
+      betterhorses.reload: true
+      betterhorses.spawn.command: true
+      betterhorses.despawn: true
+
   # Basic Permissions
   betterhorses.mount:
     description: Allows the player to mount a horse


### PR DESCRIPTION
### Motivation
- Introduce a centralized permission helper and gate features so server operators can control which players may use BetterHorses features.
- Replace ad-hoc string checks with named permission constants and normalize trait permission handling for consistency.

### Description
- Add `me.luisgamedev.betterhorses.utils.PermissionUtils` with permission constants, trait normalization helpers, and `canUseTrait`/`canReceiveTrait` helpers.
- Enforce permission checks in many listeners and commands (feeding, breeding, taming, leashing, mounting, training, trample, trait activation/use/receive, rider invulnerability/damage boost, right-click spawn, spawn/despawn commands and tab completion) and replace some string literals with `PermissionUtils` constants.
- Add new `HorsePermissionListener` to block taming and leashing without permissions and register it from `BetterHorses`.
- Update `plugin.yml` to declare the new permissions (including `betterhorses.*` aggregate) and wire children permissions for easy granting.
- Minor behavior and event updates: switch `HorseMountListener` to use `EntityMountEvent`, use `ignoreCancelled = true` on several handlers, and route trait normalization through `PermissionUtils.normalizeTraitKey`.

### Testing
- Verified the project builds successfully after the changes (compile-time checks for the modified classes completed).
- No automated unit tests were added or modified in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40ed348f7c832b93403f566319674e)