### PR TITLE
Make cooldown bypass opt-in; preserve chested inventories across undead transform; fix trample/event and trait permissions

### DIFF
--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorseKeys.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorseKeys.java
@@ -49,6 +49,8 @@ public final class BetterHorseKeys {
     public static final NamespacedKey UNDEAD_ORIGINAL_COLOR = key("undead_original_color");
     public static final NamespacedKey UNDEAD_ORIGINAL_STYLE = key("undead_original_style");
     public static final NamespacedKey UNDEAD_ARMOR_DATA = key("undead_armor_data");
+    public static final NamespacedKey UNDEAD_CHESTED = key("undead_chested");
+    public static final NamespacedKey UNDEAD_CHEST_CONTENTS = key("undead_chest_contents");
 
     private static NamespacedKey key(String key) {
         return new NamespacedKey(BetterHorses.getInstance(), key);

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/api/BetterHorsesAPI.java
@@ -546,6 +546,8 @@ public class BetterHorsesAPI {
         copyPdcKey(source, target, BetterHorseKeys.UNDEAD_ORIGINAL_COLOR, PersistentDataType.STRING);
         copyPdcKey(source, target, BetterHorseKeys.UNDEAD_ORIGINAL_STYLE, PersistentDataType.STRING);
         copyPdcKey(source, target, BetterHorseKeys.UNDEAD_ARMOR_DATA, PersistentDataType.BYTE_ARRAY);
+        copyPdcKey(source, target, BetterHorseKeys.UNDEAD_CHESTED, PersistentDataType.BYTE);
+        copyPdcKey(source, target, BetterHorseKeys.UNDEAD_CHEST_CONTENTS, PersistentDataType.STRING);
     }
 
     private static <T, Z> void copyPdcKey(PersistentDataContainer source, PersistentDataContainer target, NamespacedKey key, PersistentDataType<T, Z> type) {

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/TrampleListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/TrampleListener.java
@@ -3,7 +3,6 @@ package me.luisgamedev.betterhorses.listeners;
 import me.luisgamedev.betterhorses.BetterHorses;
 import me.luisgamedev.betterhorses.utils.PermissionUtils;
 import me.luisgamedev.betterhorses.utils.SupportedMountType;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.AbstractHorse;
@@ -16,8 +15,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.entity.Vehicle;
 import org.bukkit.event.Listener;
-import org.bukkit.event.entity.EntityDamageByEntityEvent;
-import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
@@ -118,13 +115,7 @@ public class TrampleListener implements Listener {
             }
 
             LivingEntity target = (LivingEntity) entity;
-            EntityDamageByEntityEvent damageEvent = createTrampleDamageEvent(rider, target, config);
-            Bukkit.getPluginManager().callEvent(damageEvent);
-            if (damageEvent.isCancelled()) {
-                continue;
-            }
-
-            applyTrample(rider, horseLocation, target, config, currentTick, damageEvent);
+            applyTrample(rider, horseLocation, target, config, currentTick);
         }
     }
 
@@ -163,24 +154,15 @@ public class TrampleListener implements Listener {
         return dot >= minimumDot;
     }
 
-    private EntityDamageByEntityEvent createTrampleDamageEvent(Player rider, LivingEntity target, FileConfiguration config) {
+    private void applyTrample(Player rider, Location horseLocation, LivingEntity target, FileConfiguration config, long currentTick) {
         double damage = Math.max(0.0, config.getDouble("trample.damage", 4.0));
-        return new EntityDamageByEntityEvent(
-                rider,
-                target,
-                EntityDamageEvent.DamageCause.ENTITY_ATTACK,
-                damage
-        );
-    }
-
-    private void applyTrample(Player rider, Location horseLocation, LivingEntity target, FileConfiguration config, long currentTick, EntityDamageByEntityEvent damageEvent) {
         double knockbackStrength = Math.max(0.0, config.getDouble("trample.knockback", 1.2));
 
         int cooldownTicks = Math.max(0, config.getInt("trample.cooldown-ticks", 20));
         targetCooldowns.put(target.getUniqueId(), currentTick + cooldownTicks);
 
-        if (damageEvent.getDamage() > 0.0) {
-            target.damage(damageEvent.getDamage(), rider);
+        if (damage > 0.0) {
+            target.damage(damage, rider);
         }
 
         if (knockbackStrength > 0.0) {

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/UndeadTraitListener.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/listeners/UndeadTraitListener.java
@@ -15,6 +15,7 @@ import org.bukkit.Sound;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.AbstractHorse;
+import org.bukkit.entity.ChestedHorse;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Horse;
 import org.bukkit.entity.Player;
@@ -29,7 +30,13 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.util.io.BukkitObjectInputStream;
+import org.bukkit.util.io.BukkitObjectOutputStream;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
 import java.util.List;
 import java.util.Locale;
 
@@ -68,9 +75,19 @@ public class UndeadTraitListener implements Listener {
         if (!isUndeadSkeleton(skeleton)) return;
         PersistentDataContainer data = skeleton.getPersistentDataContainer();
         ItemStack armor = readStoredArmor(data);
-        if (armor == null) return;
-        data.remove(BetterHorseKeys.UNDEAD_ARMOR_DATA);
-        skeleton.getWorld().dropItemNaturally(skeleton.getLocation(), armor);
+        if (armor != null) {
+            data.remove(BetterHorseKeys.UNDEAD_ARMOR_DATA);
+            skeleton.getWorld().dropItemNaturally(skeleton.getLocation(), armor);
+        }
+        ItemStack[] chestContents = readStoredChestContents(data);
+        if (chestContents != null) {
+            data.remove(BetterHorseKeys.UNDEAD_CHEST_CONTENTS);
+            for (ItemStack item : chestContents) {
+                if (item != null && !item.getType().isAir()) {
+                    skeleton.getWorld().dropItemNaturally(skeleton.getLocation(), item);
+                }
+            }
+        }
     }
 
     private boolean canUseUndeadTrait(AbstractHorse horse) {
@@ -91,6 +108,8 @@ public class UndeadTraitListener implements Listener {
         double jump = getAttribute(original, AttributeResolver.horseJumpStrength(), 0.7);
         ItemStack armor = HorseArmorUtils.getArmor(original.getInventory());
         ItemStack saddle = original.getInventory().getSaddle();
+        boolean carryingChest = original instanceof ChestedHorse chestedHorse && chestedHorse.isCarryingChest();
+        String chestContents = carryingChest ? serializeStorageContents(original.getInventory().getStorageContents()) : null;
 
         SkeletonHorse skeleton = location.getWorld().spawn(location, SkeletonHorse.class);
         copyBetterHorsesData(oldData, skeleton.getPersistentDataContainer());
@@ -105,6 +124,10 @@ public class UndeadTraitListener implements Listener {
             data.set(BetterHorseKeys.UNDEAD_ORIGINAL_STYLE, PersistentDataType.STRING, h.getStyle().name());
         }
         if (armor != null) data.set(BetterHorseKeys.UNDEAD_ARMOR_DATA, PersistentDataType.BYTE_ARRAY, armor.serializeAsBytes());
+        if (carryingChest) {
+            data.set(BetterHorseKeys.UNDEAD_CHESTED, PersistentDataType.BYTE, (byte) 1);
+            if (chestContents != null) data.set(BetterHorseKeys.UNDEAD_CHEST_CONTENTS, PersistentDataType.STRING, chestContents);
+        }
         applyStats(skeleton, maxHealth, speed, jump);
         skeleton.setHealth(maxHealth);
         skeleton.setTamed(original.isTamed());
@@ -135,6 +158,7 @@ public class UndeadTraitListener implements Listener {
         restored.setTamed(skeleton.isTamed());
         restored.setOwner(skeleton.getOwner());
         restored.getInventory().setSaddle(skeleton.getInventory().getSaddle());
+        restoreChestContents(restored, data);
         if (restored instanceof Horse horse) {
             setHorseVariant(horse, data.get(BetterHorseKeys.UNDEAD_ORIGINAL_COLOR, PersistentDataType.STRING), data.get(BetterHorseKeys.UNDEAD_ORIGINAL_STYLE, PersistentDataType.STRING));
             ItemStack armor = readStoredArmor(data);
@@ -177,7 +201,30 @@ public class UndeadTraitListener implements Listener {
         }
     }
     private <T, Z> void copyKey(PersistentDataContainer from, PersistentDataContainer to, org.bukkit.NamespacedKey key, PersistentDataType<T, Z> type) { if (from.has(key, type)) to.set(key, type, from.get(key, type)); }
-    private void cleanupUndeadKeys(PersistentDataContainer data) { data.remove(BetterHorseKeys.UNDEAD_SKELETON); data.remove(BetterHorseKeys.UNDEAD_ORIGINAL_TYPE); data.remove(BetterHorseKeys.UNDEAD_ORIGINAL_HEALTH); data.remove(BetterHorseKeys.UNDEAD_ORIGINAL_SPEED); data.remove(BetterHorseKeys.UNDEAD_ORIGINAL_JUMP); data.remove(BetterHorseKeys.UNDEAD_ORIGINAL_COLOR); data.remove(BetterHorseKeys.UNDEAD_ORIGINAL_STYLE); data.remove(BetterHorseKeys.UNDEAD_ARMOR_DATA); }
+    private void cleanupUndeadKeys(PersistentDataContainer data) { data.remove(BetterHorseKeys.UNDEAD_SKELETON); data.remove(BetterHorseKeys.UNDEAD_ORIGINAL_TYPE); data.remove(BetterHorseKeys.UNDEAD_ORIGINAL_HEALTH); data.remove(BetterHorseKeys.UNDEAD_ORIGINAL_SPEED); data.remove(BetterHorseKeys.UNDEAD_ORIGINAL_JUMP); data.remove(BetterHorseKeys.UNDEAD_ORIGINAL_COLOR); data.remove(BetterHorseKeys.UNDEAD_ORIGINAL_STYLE); data.remove(BetterHorseKeys.UNDEAD_ARMOR_DATA); data.remove(BetterHorseKeys.UNDEAD_CHESTED); data.remove(BetterHorseKeys.UNDEAD_CHEST_CONTENTS); }
     private ItemStack readStoredArmor(PersistentDataContainer data) { byte[] bytes = data.get(BetterHorseKeys.UNDEAD_ARMOR_DATA, PersistentDataType.BYTE_ARRAY); if (bytes == null || bytes.length == 0) return null; try { return ItemStack.deserializeBytes(bytes); } catch (Exception ignored) { return null; } }
+    private void restoreChestContents(AbstractHorse horse, PersistentDataContainer data) {
+        if (!(horse instanceof ChestedHorse chestedHorse) || !data.has(BetterHorseKeys.UNDEAD_CHESTED, PersistentDataType.BYTE)) return;
+        chestedHorse.setCarryingChest(true);
+        ItemStack[] contents = readStoredChestContents(data);
+        if (contents != null) horse.getInventory().setStorageContents(contents);
+    }
+    private String serializeStorageContents(ItemStack[] contents) {
+        try (ByteArrayOutputStream bytes = new ByteArrayOutputStream(); BukkitObjectOutputStream output = new BukkitObjectOutputStream(bytes)) {
+            output.writeInt(contents.length);
+            for (ItemStack item : contents) output.writeObject(item);
+            return Base64.getEncoder().encodeToString(bytes.toByteArray());
+        } catch (IOException ignored) { return null; }
+    }
+    private ItemStack[] readStoredChestContents(PersistentDataContainer data) {
+        String serialized = data.get(BetterHorseKeys.UNDEAD_CHEST_CONTENTS, PersistentDataType.STRING);
+        if (serialized == null || serialized.isBlank()) return null;
+        try (ByteArrayInputStream bytes = new ByteArrayInputStream(Base64.getDecoder().decode(serialized)); BukkitObjectInputStream input = new BukkitObjectInputStream(bytes)) {
+            int length = input.readInt();
+            ItemStack[] contents = new ItemStack[length];
+            for (int i = 0; i < length; i++) contents[i] = (ItemStack) input.readObject();
+            return contents;
+        } catch (IOException | ClassNotFoundException | IllegalArgumentException | ClassCastException ignored) { return null; }
+    }
     private void setHorseVariant(Horse horse, String color, String style) { try { if (color != null) horse.setColor(Horse.Color.valueOf(color)); } catch (IllegalArgumentException ignored) {} try { if (style != null) horse.setStyle(Horse.Style.valueOf(style)); } catch (IllegalArgumentException ignored) {} }
 }

--- a/BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/PermissionUtils.java
+++ b/BetterHorses/src/main/java/me/luisgamedev/betterhorses/utils/PermissionUtils.java
@@ -16,7 +16,10 @@ public final class PermissionUtils {
             "kickback",
             "ghosthorse",
             "heavenhooves",
-            "undead"
+            "undead",
+            "frosthooves",
+            "skyburst",
+            "revenantcurse"
     );
 
     private PermissionUtils() {

--- a/BetterHorses/src/main/resources/plugin.yml
+++ b/BetterHorses/src/main/resources/plugin.yml
@@ -41,6 +41,9 @@ permissions:
       betterhorses.trait.ghosthorse: true
       betterhorses.trait.heavenhooves: true
       betterhorses.trait.undead: true
+      betterhorses.trait.frosthooves: true
+      betterhorses.trait.skyburst: true
+      betterhorses.trait.revenantcurse: true
       betterhorses.info: true
       betterhorses.neuter: true
       betterhorses.create: true
@@ -60,6 +63,9 @@ permissions:
       betterhorses.trait.ghosthorse: true
       betterhorses.trait.heavenhooves: true
       betterhorses.trait.undead: true
+      betterhorses.trait.frosthooves: true
+      betterhorses.trait.skyburst: true
+      betterhorses.trait.revenantcurse: true
 
   betterhorses.rider.*:
     description: Grants access to all rider bonuses
@@ -114,7 +120,7 @@ permissions:
 
   betterhorses.cooldown.bypass:
     description: Allows the player to bypass breeding cooldowns
-    default: true
+    default: false
 
   betterhorses.rider.invincible:
     description: Allows the rider to use the rider invincibility feature
@@ -163,6 +169,18 @@ permissions:
 
   betterhorses.trait.undead:
     description: Allows the rider to use the trait undead if enabled
+    default: true
+
+  betterhorses.trait.frosthooves:
+    description: Allows the rider to use the trait frosthooves if enabled
+    default: true
+
+  betterhorses.trait.skyburst:
+    description: Allows the rider to use the trait skyburst if enabled
+    default: true
+
+  betterhorses.trait.revenantcurse:
+    description: Allows the rider to use the trait revenantcurse if enabled
     default: true
 
   # Command permissions


### PR DESCRIPTION
### Motivation

- Prevent servers from unintentionally granting `betterhorses.cooldown.bypass` to all players by making the bypass opt-in instead of the default. 
- Ensure that chested donkeys/mules do not lose their chest contents when transformed to or from undead skeleton horses.  
- Avoid double-dispatching trample damage events that produce duplicated listener effects and squared damage boosts, and ensure trait-specific permissions are enforced for all implemented traits.

### Description

- Change the `betterhorses.cooldown.bypass` permission default to `false` in `BetterHorses/src/main/resources/plugin.yml` so bypass is opt-in.  
- Add `frosthooves`, `skyburst`, and `revenantcurse` to the trait allowlist in `PermissionUtils` and declare their permission nodes in `plugin.yml`.  
- Remove manual `EntityDamageByEntityEvent` creation in `TrampleListener` and apply damage exactly once via `target.damage(...)`, letting Bukkit generate the event.  
- Preserve chested mount state by adding `UNDEAD_CHESTED` and `UNDEAD_CHEST_CONTENTS` keys to `BetterHorseKeys`, serializing chest contents on transform, copying those PDC keys in `BetterHorsesAPI`, and restoring or dropping stored chest items in `UndeadTraitListener` (with robust serialize/deserialize helpers).

### Testing

- Ran `git diff --check` and it reported no whitespace or diff-check issues.  
- Parsed `BetterHorses/src/main/resources/plugin.yml` with Ruby YAML to validate the YAML structure and it succeeded.  
- Attempted `./gradlew clean build` but the build failed due to the environment JVM/Gradle mismatch (`Unsupported class file major version 69`) so a full artifact build could not be completed here.  
- Attempted to install Java 21 to run the build but the toolchain download was blocked by the environment network, preventing a successful `gradlew` build in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76cfaba8e4832bad7e7e6505171b20)